### PR TITLE
sys/strings: add module for special string types

### DIFF
--- a/src/sys/strings.nim
+++ b/src/sys/strings.nim
@@ -1,0 +1,122 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+## Special kinds of strings used for interacting with certain operating system
+## APIs.
+##
+## While mutating APIs are provided, they are limited to simple operations
+## only. For performance it is recommended to convert them to strings, perform
+## the necessary mutations, then use the checked converters.
+
+import std/strutils
+
+type
+  Without*[C: static set[char]] = distinct string
+    ## A distinct string type without the characters in set `C`.
+
+const
+  InvalidChar = "$1 is not a valid character for this type of string."
+    # Error message used for setting an invalid character.
+
+  FoundInvalid = "Invalid character ($1) found at position $2"
+    # Error message used when an invalid character is found during search.
+
+template len*(w: Without): int =
+  ## Obtain the length of the string `w`.
+  w.string.len
+
+template `==`*(a, b: Without): bool =
+  ## Returns whether `a` and `b` are equal.
+  a.string == b.string
+
+template `==`*(a: Without, b: string): bool =
+  ## Returns whether `a` and `b` are equal.
+  a.string == b
+
+template `==`*(a: string, b: Without): bool =
+  ## Returns whether `a` and `b` are equal.
+  a == b.string
+
+template `[]`*(w: Without, i: Natural): char =
+  ## Obtain the byte at position `i` of the string `w`.
+  w.string[i]
+
+template `[]`*(w: Without, i: BackwardsIndex): char =
+  ## Obtain the byte at position `i` of the string `w`.
+  w.string[i]
+
+func `[]=`*[C](w: var Without[C], i: Natural, c: char)
+              {.inline, raises: [ValueError].} =
+  ## Set the byte at position `i` of the string `w` to `c`.
+  ##
+  ## Raises `ValueError` if `c` is in `C`.
+  if c notin C:
+    string(w)[i] = c
+  else:
+    raise newException(ValueError, InvalidChar % escape $c)
+
+func toWithout*(s: sink string, C: static set[char]): Without[C]
+               {.inline, raises: [ValueError].} =
+  ## Checked conversion to `Without[C]`, raises `ValueError` if any character
+  ## in `C` was found in the string.
+  let invalidPos = s.find C
+  if invalidPos != -1:
+    raise newException(
+      ValueError,
+      FoundInvalid % [escape $s[invalidPos], $invalidPos]
+    )
+  result = Without[C](s)
+
+func filter*(s: string, C: static set[char]): Without[C] {.raises: [].} =
+  ## Remove characters in set `C` from `s` and create a `Without[C]`.
+  var i = 0
+  result = Without[C](s)
+  while i < result.len:
+    if result[i] in C:
+      result.string.delete(i, i)
+    else:
+      inc i
+
+template add*[C](w: var Without[C], s: Without[C]) =
+  ## Append the string `s` to `w`.
+  w.string.add s.string
+
+func add*[C](w: var Without[C], s: string) =
+  ## Append the string `s` to `w`.
+  ##
+  ## Raises `ValueError` if any character in `C` if found in the string `s`.
+  let origLen = w.len
+  try:
+    w.string.setLen origLen + s.len
+    for idx, c in s:
+      w[origLen + idx] = c
+  except:
+    # Clean up on failure
+    w.string.setLen origLen
+    raise
+
+func add*[C](w: var Without[C], c: char) {.inline, raises: [ValueError].} =
+  ## Append the character `c` to `w`.
+  ##
+  ## Raises `ValueError` if `c` is in `C`.
+  if c notin C:
+    w.string.add c
+  else:
+    raise newException(ValueError, InvalidChar % escape $c)
+
+type
+  Nulless* = Without[{'\0'}]
+    ## A string without the character NUL, mainly used for file paths or
+    ## command arguments.
+
+func toNulless*(s: sink string): Nulless
+               {.inline, raises: [ValueError].} =
+  ## Checked conversion to `NullessString`.
+  ##
+  ## Raises `ValueError` if any NUL character was found in the string.
+  s.toWithout({'\0'})

--- a/src/sys/strings.nim
+++ b/src/sys/strings.nim
@@ -47,7 +47,7 @@ template `[]`*(w: Without, i: Natural): char =
   w.string[i]
 
 template `[]`*(w: Without, i: BackwardsIndex): char =
-  ## Obtain the byte at position `i` of the string `w`.
+  ## Obtain the byte at position `w.len - i` of the string `w`.
   w.string[i]
 
 func `[]=`*[C](w: var Without[C], i: Natural, c: char)
@@ -62,8 +62,9 @@ func `[]=`*[C](w: var Without[C], i: Natural, c: char)
 
 func toWithout*(s: sink string, C: static set[char]): Without[C]
                {.inline, raises: [ValueError].} =
-  ## Checked conversion to `Without[C]`, raises `ValueError` if any character
-  ## in `C` was found in the string.
+  ## Checked conversion to `Without[C]`.
+  ##
+  ## Raises `ValueError` if any character in `C` was found in the string.
   let invalidPos = s.find C
   if invalidPos != -1:
     raise newException(

--- a/src/sys/strings.nim
+++ b/src/sys/strings.nim
@@ -73,6 +73,19 @@ func toWithout*(s: sink string, C: static set[char]): Without[C]
     )
   result = Without[C](s)
 
+func toWithout*[A](w: sink Without[A], C: static set[char]): Without[C]
+               {.inline, raises: [ValueError].} =
+  ## Convert between `Without` types.
+  ##
+  ## Raises `ValueError` if any character in `C` was found in the string.
+  ##
+  ## When `A` is equal to `C`, `w` will be returned and no check occurs. This
+  ## makes it useful for use in generics.
+  when A == C:
+    w
+  else:
+    w.string.toWithout(C)
+
 func filter*(s: string, C: static set[char]): Without[C] {.raises: [].} =
   ## Remove characters in set `C` from `s` and create a `Without[C]`.
   var i = 0
@@ -82,6 +95,17 @@ func filter*(s: string, C: static set[char]): Without[C] {.raises: [].} =
       result.string.delete(i, i)
     else:
       inc i
+
+func filter*[A](w: Without[A], C: static set[char]): Without[C]
+               {.raises: [].} =
+  ## Remove characters in set `C` from `w` and create a `Without[C]`.
+  ##
+  ## When `A` is equal to `C`, `w` will be returned. This makes it useful for
+  ## use in generics.
+  when A == C:
+    w
+  else:
+    w.string.filter(C)
 
 template add*[C](w: var Without[C], s: Without[C]) =
   ## Append the string `s` to `w`.
@@ -121,3 +145,8 @@ func toNulless*(s: sink string): Nulless
   ##
   ## Raises `ValueError` if any NUL character was found in the string.
   s.toWithout({'\0'})
+
+func toNulless*(s: sink Nulless): Nulless
+               {.inline, raises: [].} =
+  ## Returns `s`. This function is provided for use in generics.
+  s

--- a/tests/strings/tnulless.nim
+++ b/tests/strings/tnulless.nim
@@ -1,0 +1,66 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+import pkg/balls
+import sys/strings
+
+suite "Nulless tests":
+  test "Converting a string without NUL is error-free":
+    discard "NUL-less".toNulless
+
+  test "Converting a string with NUL raises ValueError":
+    expect ValueError:
+      discard "NUL\0here".toNulless
+
+  test "filter() don't affect compilant strings":
+    check "NUL-less" == "NUL-less".filter({'\0'})
+
+  test "filter() filters non-compliant characters":
+    check "NUL\0here".filter({'\0'}) == "NULhere".toNulless
+
+  test "Read operators":
+    let sample = "NUL-less".toNulless
+    check sample[0] == 'N'
+    check sample[^1] == 's'
+
+  test "Assigning compilant character":
+    var sample = "NUL-less".toNulless
+    sample[0] = 'n'
+
+  test "Assigning non-compilant character raises ValueError":
+    var sample = "NUL-less".toNulless
+    expect ValueError:
+      sample[0] = '\0'
+    check sample == "NUL-less"
+
+  test "Nulless can be added to Nulless":
+    var sample = "NUL".toNulless
+    sample.add "-less".toNulless
+    check sample == "NUL-less"
+
+  test "Adding compilant character":
+    var sample = "NUL".toNulless
+    sample.add '-'
+    check sample == "NUL-"
+
+  test "Adding non-compilant character raises ValueError":
+    var sample = "NUL".toNulless
+    expect ValueError:
+      sample.add '\0'
+    check sample == "NUL"
+
+  test "Adding compilant string":
+    var sample = "NUL".toNulless
+    sample.add "-less"
+    check sample == "NUL-less"
+
+  test "Adding non-compilant string raises":
+    var sample = "NUL".toNulless
+    expect ValueError:
+      sample.add "-\0less"
+    check sample == "NUL"

--- a/tests/strings/tnulless.nim
+++ b/tests/strings/tnulless.nim
@@ -64,3 +64,24 @@ suite "Nulless tests":
     expect ValueError:
       sample.add "-\0less"
     check sample == "NUL"
+
+  test "filter() to the same type doesn't change anything":
+    let sample = "NUL-less".toNulless
+    check sample.filter({'\0'}) == sample
+
+  test "filter() works cross type":
+    let sample = "ab\0c".toWithout({'$'})
+    check sample.filter({'\0'}) == "abc".toNulless
+
+  test "toWithout() to the same type have no effect":
+    let sample = "NUL-less".toNulless
+    check sample.toWithout({'\0'}) == sample
+
+  test "toWithout() captures error cross-type":
+    let sample = "NUL-less".toNulless
+    expect ValueError:
+      discard sample.toWithout({'N', 'U', 'L'})
+
+  test "toNulless() is a no-op when used on Nulless":
+    let sample = "NUL-less".toNulless
+    check sample.toNulless == sample


### PR DESCRIPTION
Not every character in a string is valid for certain OS APIs, so we need
a typesafe way to declare strings with such requirements.

Fixes #2 