### PR TITLE
sys/files(windows): make setPos a proc

### DIFF
--- a/src/sys/private/files_windows.nim
+++ b/src/sys/private/files_windows.nim
@@ -80,7 +80,7 @@ template readImpl() {.dirty.} =
     else:
       doAssert false, "unreachable!"
 
-func setPos(overlapped: CustomRef, pos: uint64) {.inline.} =
+proc setPos(overlapped: CustomRef, pos: uint64) {.inline.} =
   overlapped.offset = DWORD(pos and high uint32)
   overlapped.offsetHigh = DWORD(pos shr 32)
 


### PR DESCRIPTION
It modifies `overlapped`, which is a `ref`, thus tripping strictFunc.