### PR TITLE
sys(treewide): replace asyncdispatch with ioqueue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-4, devel]
+        branch: [devel]
         target: [linux, macos, windows]
         arch: [i386, amd64]
         include:
@@ -78,7 +78,7 @@ jobs:
         run: |
           branch=${{ github.ref }}
           branch=${branch##*/}
-          for i in src/sys/*.nim; do
+          for i in src/sys/*.nim src/sys/ioqueue/*.nim; do
             nimble doc --project --outdir:htmldocs \
               '--git.url:https://github.com/${{ github.repository }}' \
               '--git.commit:${{ github.sha }}' \

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # An abstraction layer for common operating system services
 
 [![CI status](https://github.com/alaviss/nim-sys/workflows/CI/badge.svg)](https://github.com/alaviss/nim-sys/actions?query=workflow%3ACI)
-![Minimum supported Nim version](https://img.shields.io/badge/nim-1.4.0%2B-informational?style=flat&logo=nim)
+![Minimum supported Nim version](https://img.shields.io/badge/nim-1.5.1%2B-informational?style=flat&logo=nim)
 [![License](https://img.shields.io/github/license/alaviss/nim-sys?style=flat)](#license)
 
 This package is an experiment in rewriting various parts of stdlib's `os` module.

--- a/src/sys/ioqueue.nim
+++ b/src/sys/ioqueue.nim
@@ -75,6 +75,11 @@ else:
     ## Initializes the event queue for processing.
     initImpl()
 
+  template asyncio*(prc: typed): untyped =
+    ## Convenience alias to `{.cps: Continuation.}` for procedures wishing
+    ## to use ioqueue.
+    cps(Continuation, prc)
+
   proc running*(): bool =
     ## Whether there are any continuations within the queue
     runningImpl()

--- a/src/sys/ioqueue.nim
+++ b/src/sys/ioqueue.nim
@@ -7,161 +7,159 @@
 # the file "license.txt" included with this distribution. Alternatively,
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
-when defined(nimdoc) and (NimMajor, NimMinor) < (1, 5):
-  discard "You can't use it so docgen can't either"
+## A per-thread eventqueue for dispatching over I/O
+##
+## This is not meant to be a full-fledged eventqueue but rather a
+## supplementary for other queues implementation.
+
+import handles
+import std/[options, times]
+import pkg/cps
+export cps
+
+type
+  Event* {.pure.} = enum
+    ## Events that the operating system can signal.
+    Read ## The resource is ready to be read from.
+    Write ## The resource is ready to be written to.
+    PriorityRead ## The resource has high-priority data available to be read.
+
+    Error ## There is an error associated with the resource.
+    Hangup ## The resource has been hung up, usually this means
+           ## a peer has closed its end of the channel.
+
+  ReadyEvent* = range[Read..PriorityRead]
+    ## Events that can be registered to be waited for
+
+  PrematureCloseDefect* = object of Defect
+    ## A defect raised when a resource was invalidated while there is a
+    ## waiter for it in the queue.
+    ##
+    ## This is considered a programming error due to the fact that some
+    ## operating system might keep reporting events for the "closed" resource
+    ## since it might be kept alive by other hidden references (ie. `dup` on
+    ## a fd will cause epoll to keep reporting event for the original even
+    ## if the original is closed).
+    ##
+    ## To avoid this, unregister the resource from the queue before invalidating
+    ## it.
+    id*: int ## The unique ID of the resource, typically the resource handle,
+             ## but is dependant on the target operating system.
+
+func newPrematureCloseDefect*(id: int): ref PrematureCloseDefect =
+  ## Creates a `PrematureCloseDefect`
+  result = newException(PrematureCloseDefect):
+    "Resource id " & $id & " was invalidated before its waiter could execute"
+  result.id = id
+
+when defined(linux):
+  include private/ioqueue_linux
+elif defined(macosx) or defined(bsd):
+  include private/ioqueue_bsd
+elif defined(windows):
+  include private/ioqueue_windows
+
+  import ioqueue/iocp {.all.}
+  export iocp except init, running, unregister, poll
 else:
-  ## A per-thread eventqueue for dispatching over I/O
+  {.error: "This module has not been ported to your operating system".}
+
+type
+  EventQueue = EventQueueImpl
+
+var eq {.threadvar, used.}: EventQueue
+
+proc init() =
+  ## Initializes the event queue for processing.
+  initImpl()
+
+template asyncio*(prc: typed): untyped =
+  ## Convenience alias to `{.cps: Continuation.}` for procedures wishing
+  ## to use ioqueue.
+  cps(Continuation, prc)
+
+proc running*(): bool =
+  ## Whether there are any continuations within the queue
+  runningImpl()
+
+proc poll*(runnable: var seq[Continuation], timeout = none(Duration)) =
+  ## Poll the operating system for events and add continuations of which the
+  ## resources they are waiting for are ready to `runnable`.
   ##
-  ## This is not meant to be a full-fledged eventqueue but rather a
-  ## supplementary for other queues implementation.
+  ## If `timeout` is `none(Duration)`, wait indefinitely until the operating
+  ## system signals an event.
+  ## If `timeout` is `DurationZero`, returns immediately iff there aren't any
+  ## continuations ready to be run.
+  ##
+  ## `timeout` is not precise, and the actual wait time depends on the target
+  ## operating system.
+  ##
+  ## If the queue is empty, returns immediately.
+  pollImpl()
 
-  import handles
-  import std/[options, times]
-  import pkg/cps
+proc run*() =
+  ## Wait for events and run all pending continuations in the queue. Stops
+  ## when the queue is empty.
+  var runnable: seq[Continuation]
+  while running():
+    # Get the continuations that are ready to be run.
+    poll(runnable)
+    # Run until the list is empty.
+    while runnable.len > 0:
+      discard trampoline runnable.pop()
 
-  type
-    Event* {.pure.} = enum
-      ## Events that the operating system can signal.
-      Read ## The resource is ready to be read from.
-      Write ## The resource is ready to be written to.
-      PriorityRead ## The resource has high-priority data available to be read.
+using c: Continuation
 
-      Error ## There is an error associated with the resource.
-      Hangup ## The resource has been hung up, usually this means
-             ## a peer has closed its end of the channel.
+when not declared(waitEventImpl):
+  template waitEventImpl() {.dirty.} =
+    {.error: "This operation is not available for your target platform".}
 
-    ReadyEvent* = range[Read..PriorityRead]
-      ## Events that can be registered to be waited for
+proc wait*(c; fd: AnyFD, event: ReadyEvent): Continuation {.cpsMagic.} =
+  ## Wait for the specified `fd` to be ready for the given `event`.
+  ##
+  ## For higher efficiency, only wait for ready state when the `fd` signalled
+  ## that it is not ready.
+  ##
+  ## Only one continuation can be queued for any given `fd` per thread. If
+  ## more than one is queued, ValueError will be raised.
+  ##
+  ## **Note**: Any `fd` registered into the queue (via this procedure) should be
+  ## unregistered before it is closed as the semantics differs between operating
+  ## system for when an FD is closed while in the queue. If such scenario is
+  ## detected, `PrematureCloseDefect` will be raised.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - This interface is not implemented on Windows since IOCP can be used to cover
+  ##   every use cases of this interface.
+  init()
+  waitEventImpl()
 
-    PrematureCloseDefect* = object of Defect
-      ## A defect raised when a resource was invalidated while there is a
-      ## waiter for it in the queue.
-      ##
-      ## This is considered a programming error due to the fact that some
-      ## operating system might keep reporting events for the "closed" resource
-      ## since it might be kept alive by other hidden references (ie. `dup` on
-      ## a fd will cause epoll to keep reporting event for the original even
-      ## if the original is closed).
-      ##
-      ## To avoid this, unregister the resource from the queue before invalidating
-      ## it.
-      id*: int ## The unique ID of the resource, typically the resource handle,
-               ## but is dependant on the target operating system.
+proc wait*(c; fd: Handle[AnyFD], event: ReadyEvent): Continuation {.cpsMagic.} =
+  ## An overload of `wait` for `Handle`.
+  ioqueue.wait(c, fd.get, event)
 
-  func newPrematureCloseDefect*(id: int): ref PrematureCloseDefect =
-    ## Creates a `PrematureCloseDefect`
-    result = newException(PrematureCloseDefect):
-      "Resource id " & $id & " was invalidated before its waiter could execute"
-    result.id = id
+when not declared(unregisterImpl):
+  template unregisterImpl() {.dirty.} =
+    {.error: "This operation is not available for your target platform".}
 
-  when defined(linux):
-    include private/ioqueue_linux
-  elif defined(macosx) or defined(bsd):
-    include private/ioqueue_bsd
-  elif defined(windows):
-    include private/ioqueue_windows
+proc unregister*(fd: AnyFD) =
+  ## If `fd` was registered in the queue, remove it alongside its
+  ## continuation.
+  ##
+  ## Does nothing if the `fd` is not in the queue.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On Windows, `unregister` will abort all ongoing IO in `fd` and its
+  ##   resources will only be collected in the next `poll()` iff the
+  ##   queue is still running.
+  ##
+  ## - On Windows, `poll()` might still be interrupted by activities on `fd`
+  ##   even after unregistration since `fd` will only be detached from IOCP
+  ##   *after* it and its duplicates are closed.
+  unregisterImpl()
 
-    import ioqueue/iocp {.all.}
-    export iocp
-  else:
-    {.error: "This module has not been ported to your operating system".}
-
-  type
-    EventQueue = EventQueueImpl
-
-  var eq {.threadvar, used.}: EventQueue
-
-  proc init() =
-    ## Initializes the event queue for processing.
-    initImpl()
-
-  template asyncio*(prc: typed): untyped =
-    ## Convenience alias to `{.cps: Continuation.}` for procedures wishing
-    ## to use ioqueue.
-    cps(Continuation, prc)
-
-  proc running*(): bool =
-    ## Whether there are any continuations within the queue
-    runningImpl()
-
-  proc poll*(runnable: var seq[Continuation], timeout = none(Duration)) =
-    ## Poll the operating system for events and add continuations of which the
-    ## resources they are waiting for are ready to `runnable`.
-    ##
-    ## If `timeout` is `none(Duration)`, wait indefinitely until the operating
-    ## system signals an event.
-    ## If `timeout` is `DurationZero`, returns immediately iff there aren't any
-    ## continuations ready to be run.
-    ##
-    ## `timeout` is not precise, and the actual wait time depends on the target
-    ## operating system.
-    ##
-    ## If the queue is empty, returns immediately.
-    pollImpl()
-
-  proc run*() =
-    ## Wait for events and run all pending continuations in the queue. Stops
-    ## when the queue is empty.
-    var runnable: seq[Continuation]
-    while running():
-      # Get the continuations that are ready to be run.
-      poll(runnable)
-      # Run until the list is empty.
-      while runnable.len > 0:
-        discard trampoline runnable.pop()
-
-  using c: Continuation
-
-  when not declared(waitEventImpl):
-    template waitEventImpl() {.dirty.} =
-      {.error: "This operation is not available for your target platform".}
-
-  proc wait*(c; fd: AnyFD, event: ReadyEvent): Continuation {.cpsMagic.} =
-    ## Wait for the specified `fd` to be ready for the given `event`.
-    ##
-    ## For higher efficiency, only wait for ready state when the `fd` signalled
-    ## that it is not ready.
-    ##
-    ## Only one continuation can be queued for any given `fd` per thread. If
-    ## more than one is queued, ValueError will be raised.
-    ##
-    ## **Note**: Any `fd` registered into the queue (via this procedure) should be
-    ## unregistered before it is closed as the semantics differs between operating
-    ## system for when an FD is closed while in the queue. If such scenario is
-    ## detected, `PrematureCloseDefect` will be raised.
-    ##
-    ## **Platform specific details**
-    ##
-    ## - This interface is not implemented on Windows since IOCP can be used to cover
-    ##   every use cases of this interface.
-    init()
-    waitEventImpl()
-
-  proc wait*(c; fd: Handle[AnyFD], event: ReadyEvent): Continuation {.cpsMagic.} =
-    ## An overload of `wait` for `Handle`.
-    ioqueue.wait(c, fd.get, event)
-
-  when not declared(unregisterImpl):
-    template unregisterImpl() {.dirty.} =
-      {.error: "This operation is not available for your target platform".}
-
-  proc unregister*(fd: AnyFD) =
-    ## If `fd` was registered in the queue, remove it alongside its
-    ## continuation.
-    ##
-    ## Does nothing if the `fd` is not in the queue.
-    ##
-    ## **Platform specific details**
-    ##
-    ## - On Windows, `unregister` will abort all ongoing IO in `fd` and its
-    ##   resources will only be collected in the next `poll()` iff the
-    ##   queue is still running.
-    ##
-    ## - On Windows, `poll()` might still be interrupted by activities on `fd`
-    ##   even after unregistration since `fd` will only be detached from IOCP
-    ##   *after* it and its duplicates are closed.
-    unregisterImpl()
-
-  proc unregister*(fd: Handle[AnyFD]) =
-    ## An overload of `unregister` for `Handle`
-    ioqueue.unregister(fd.get)
+proc unregister*(fd: Handle[AnyFD]) =
+  ## An overload of `unregister` for `Handle`
+  ioqueue.unregister(fd.get)

--- a/src/sys/pipes.nim
+++ b/src/sys/pipes.nim
@@ -9,7 +9,7 @@
 ## Abstractions for operating system pipes and FIFOs (named pipes).
 
 import system except File
-import std/[asyncdispatch, typetraits]
+import std/typetraits
 import files
 
 const
@@ -128,11 +128,20 @@ template read*[T: byte or char](rp: ReadPipe, b: var openArray[T]): int =
   ## symbol's documentation for more details.
   read distinctBase(typeof rp) rp, b
 
-template read*[T: string or seq[byte]](rp: AsyncReadPipe, b: ref T): Future[int] =
+template read*(rp: AsyncReadPipe, buf: ptr UncheckedArray[byte],
+               bufLen: Natural): int =
+  ## Read `bufLen` bytes from pipe `rp` into `buf`.
+  ##
+  ## This procedure is borrowed from
+  ## `files.read() <files.html#read,AsyncFile,ptr.UncheckedArray[byte],Natural>`_.
+  ## See the borrowed symbol's documentation for more details.
+  read distinctBase(typeof rp) rp, buf, bufLen
+
+template read*[T: string or seq[byte]](rp: AsyncReadPipe, b: ref T): int =
   ## Read `b.len` bytes from pipe `rp` into `b`.
   ##
   ## This procedure is borrowed from
-  ## `files.read() <files.html#read,AsyncFile,ref.T>`_. See the borrowed
+  ## `files.read() <files.html#read,AsyncFile,ref.string>`_. See the borrowed
   ## symbol's documentation for more details.
   read distinctBase(typeof rp) rp, b
 
@@ -144,11 +153,28 @@ template write*[T: byte or char](wp: WritePipe, b: openArray[T]) =
   ## symbol's documentation for more details.
   write distinctBase(typeof wp) wp, b
 
-template write*[T: string or seq[byte]](wp: AsyncWritePipe,
-                                        b: T): Future[void] =
+template write*(wp: AsyncWritePipe, buf: ptr UncheckedArray[byte],
+                bufLen: Natural) =
+  ## Writes `bufLen` bytes from the buffer pointed to by `buf` into the pipe
+  ## `wp`.
+  ##
+  ## This procedure is borrowed from
+  ## `files.write() <files.html#write,AsyncFile,ptr.UncheckedArray[byte],Natural>`_.
+  ## See the borrowed symbol's documentation for more details.
+  write distinctBase(typeof wp) wp, buf, bufLen
+
+template write*[T: string or seq[byte]](wp: AsyncWritePipe, b: T) =
+  ## Writes the contents of array `b` into the pipe `wp`. `b` will be copied.
+  ##
+  ## This procedure is borrowed from
+  ## `files.write() <files.html#write,AsyncFile,string>`_. See the borrowed
+  ## symbol's documentation for more details.
+  write distinctBase(typeof wp) wp, b
+
+template write*[T: string or seq[byte]](wp: AsyncWritePipe, b: ref T) =
   ## Writes the contents of array `b` into the pipe `wp`.
   ##
   ## This procedure is borrowed from
-  ## `files.write() <files.html#write,AsyncFile,T>`_. See the borrowed symbol's
-  ## documentation for more details.
+  ## `files.write() <files.html#write,AsyncFile,ref.string>`_. See the borrowed
+  ## symbol's documentation for more details.
   write distinctBase(typeof wp) wp, b

--- a/sys.nimble
+++ b/sys.nimble
@@ -9,9 +9,9 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim >= 1.4.0"
+requires "nim >= 1.5.1"
 requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
-requires "https://github.com/disruptek/cps >= 0.2.0 & < 0.3.0"
+requires "https://github.com/disruptek/cps >= 0.2.4 & < 0.3.0"
 
 # Bundled as submodule instead since the package can only be installed on Windows.
 # requires "https://github.com/khchen/winim#bffaf742b4603d1f675b4558d250d5bfeb8b6630"

--- a/tests/ioqueue/asyncio.nim
+++ b/tests/ioqueue/asyncio.nim
@@ -78,7 +78,7 @@ proc read*[T: byte or char](fd: Handle[FD], buf: var openArray[T]): int {.sync.}
     else:
       result += readBytes
 
-proc readAsync*(rd: ref Handle[FD], buf: ref string) {.cps: Continuation.} =
+proc readAsync*(rd: ref Handle[FD], buf: ref string) {.asyncio.} =
   ## Read data from `rd` until `buf` is filled or there is nothing else
   ## to be read, asynchronously.
   ##
@@ -118,7 +118,7 @@ proc readAsync*(rd: ref Handle[FD], buf: ref string) {.cps: Continuation.} =
         else:
           raise e
 
-proc writeAsync*(wr: ref Handle[FD], buf: string) {.cps: Continuation.} =
+proc writeAsync*(wr: ref Handle[FD], buf: string) {.asyncio.} =
   ## Write all bytes in `buf` into `wr` asynchronously
   when defined(windows):
     let overlapped = new Overlapped

--- a/tests/ioqueue/tqueue.nim
+++ b/tests/ioqueue/tqueue.nim
@@ -1,38 +1,37 @@
 {.experimental: "implicitDeref".}
 
-when (NimMajor, NimMinor) >= (1, 5):
-  import std/[os, strutils]
-  import pkg/balls
-  import sys/[ioqueue, handles]
+import std/[os, strutils]
+import pkg/balls
+import sys/[ioqueue, handles]
 
-  import asyncio
+import asyncio
 
-  const TestData = "!@#$%^TEST%$#@!\n"
-  let BigTestData = TestData.repeat(10 * 1024 * 1024)
-    ## A decently sized chunk of data that surpasses most OS pipe buffer size,
-    ## which is usually in the range of 4-8MiB.
-    ##
-    ## Declared as as a `let` to avoid binary size, and compiler RAM usage
-    ## from being inflated by the inlining.
+const TestData = "!@#$%^TEST%$#@!\n"
+let BigTestData = TestData.repeat(10 * 1024 * 1024)
+  ## A decently sized chunk of data that surpasses most OS pipe buffer size,
+  ## which is usually in the range of 4-8MiB.
+  ##
+  ## Declared as as a `let` to avoid binary size, and compiler RAM usage
+  ## from being inflated by the inlining.
 
-  suite "Test queue":
-    test "Multiple waiters for read/write":
-      var (rd, wr) = newAsyncPipe()
-      defer:
-        unregister rd
-        unregister wr
+suite "Test queue":
+  test "Multiple waiters for read/write":
+    var (rd, wr) = newAsyncPipe()
+    defer:
+      unregister rd
+      unregister wr
 
-      var str = new string
-      str.setLen(BigTestData.len)
+    var str = new string
+    str.setLen(BigTestData.len)
 
-      # Start the reader, it will suspend because there's nothing to read
-      rd.readAsync(str)
+    # Start the reader, it will suspend because there's nothing to read
+    rd.readAsync(str)
 
-      # Start the writer, it will suspend because our buffer is too big to
-      # write in one go
-      wr.writeAsync(BigTestData)
+    # Start the writer, it will suspend because our buffer is too big to
+    # write in one go
+    wr.writeAsync(BigTestData)
 
-      # Let's run this mess
-      run()
+    # Let's run this mess
+    run()
 
-      check str == BigTestData
+    check str == BigTestData

--- a/tests/ioqueue/tready.nim
+++ b/tests/ioqueue/tready.nim
@@ -1,7 +1,6 @@
 {.experimental: "implicitDeref".}
 
-when (NimMajor, NimMinor) >= (1, 5) and (defined(linux) or defined(macosx) or
-                                         defined(bsd)):
+when defined(linux) or defined(macosx) or defined(bsd):
   import std/[posix, os, strutils]
   import pkg/[cps, balls]
   import sys/[files, ioqueue, handles]

--- a/tests/ioqueue/tunregister.nim
+++ b/tests/ioqueue/tunregister.nim
@@ -12,7 +12,7 @@ when (NimMajor, NimMinor) >= (1, 5):
       defer:
         close rd
 
-      proc tester() {.cps: Continuation.} =
+      proc tester() {.asyncio.} =
         let buf = new string
         buf.setLen 1
         readAsync(rd, buf)

--- a/tests/ioqueue/tunregister.nim
+++ b/tests/ioqueue/tunregister.nim
@@ -1,31 +1,30 @@
 {.experimental: "implicitDeref".}
 
-when (NimMajor, NimMinor) >= (1, 5):
-  import pkg/[cps, balls]
-  import sys/[handles, ioqueue]
+import pkg/[cps, balls]
+import sys/[handles, ioqueue]
 
-  import asyncio
+import asyncio
 
-  suite "Unregistering FD from queue":
-    test "Unregistering FD prevents its continuation from being run":
-      let (rd, wr) = newAsyncPipe()
-      defer:
-        close rd
+suite "Unregistering FD from queue":
+  test "Unregistering FD prevents its continuation from being run":
+    let (rd, wr) = newAsyncPipe()
+    defer:
+      close rd
 
-      proc tester() {.asyncio.} =
-        let buf = new string
-        buf.setLen 1
-        readAsync(rd, buf)
-        fail "This code should not be run"
+    proc tester() {.asyncio.} =
+      let buf = new string
+      buf.setLen 1
+      readAsync(rd, buf)
+      fail "This code should not be run"
 
-      # Run our tester, which will be queued since the read pipe is empty
-      tester()
+    # Run our tester, which will be queued since the read pipe is empty
+    tester()
 
-      # Close the write side, which will unblock the pipe
-      close wr
+    # Close the write side, which will unblock the pipe
+    close wr
 
-      # Unregister the pipe
-      unregister rd
+    # Unregister the pipe
+    unregister rd
 
-      # Run the queue, the proc should not continue
-      run()
+    # Run the queue, the proc should not continue
+    run()


### PR DESCRIPTION
- Raise sys' Nim version requirement to be at least 1.5.1
- Removed all gating conditional for Nim < 1.5.1
- Clarified some documentation on `read`, `write`
- Migrated all asyncdispatch-based interfaces to CPS