### PR TITLE
sys/sockets: initial implementation for a networking interface

### DIFF
--- a/src/sys/ioqueue.nim
+++ b/src/sys/ioqueue.nim
@@ -168,7 +168,7 @@ proc wait*(c; fd: AnyFD, event: ReadyEvent): Continuation {.cpsMagic.} =
 
 proc wait*(c; fd: Handle[AnyFD], event: ReadyEvent): Continuation {.cpsMagic.} =
   ## An overload of `wait` for `Handle`.
-  ioqueue.wait(c, fd.get, event)
+  ioqueue.wait(c, fd.fd, event)
 
 when not declared(unregisterImpl):
   template unregisterImpl() {.dirty.} =

--- a/src/sys/ioqueue.nim
+++ b/src/sys/ioqueue.nim
@@ -46,7 +46,7 @@ type
     id*: int ## The unique ID of the resource, typically the resource handle,
              ## but is dependant on the target operating system.
 
-func newPrematureCloseDefect*(id: int): ref PrematureCloseDefect =
+proc newPrematureCloseDefect*(id: int): ref PrematureCloseDefect =
   ## Creates a `PrematureCloseDefect`
   result = newException(PrematureCloseDefect):
     "Resource id " & $id & " was invalidated before its unregistered"

--- a/src/sys/ioqueue/iocp.nim
+++ b/src/sys/ioqueue/iocp.nim
@@ -143,6 +143,8 @@ proc persist(fd: AnyFD) {.raises: [OSError].} =
   bind init
   init()
 
+  let fd = FD fd
+
   # Skip the registation check via IOCP on release build as an optimization.
   when defined(release):
     if fd in eq.registered:
@@ -225,6 +227,13 @@ proc wait*(c; fd: AnyFD, overlapped: ref Overlapped): Continuation {.cpsMagic.} 
     raise newUnregisteredHandleDefect()
 
   eq.waiters[fd] = Waiter(cont: c, overlapped: overlapped)
+
+proc wait*(c; handle: Handle[AnyFD], overlapped: ref Overlapped): Continuation {.cpsMagic.} =
+  ## Wait for the operation associated with `overlapped` to finish.
+  ##
+  ## This is an overload of `wait <#wait,,AnyFD,ref.OVERLAPPED>`_ for use with
+  ## `Handle[T]`.
+  wait(c, handle.get, overlapped)
 
 proc unregister(fd: AnyFD) {.used.} =
   ## See the documentation of `ioqueue.unregister()`

--- a/src/sys/private/addresses_posix.nim
+++ b/src/sys/private/addresses_posix.nim
@@ -1,0 +1,35 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+import syscall/posix
+
+type
+  IP4Impl {.borrow: `.`.} = distinct InAddr
+  IP6Impl {.borrow: `.`.} = distinct In6Addr
+
+template ip4Word() {.dirty.} =
+  result = ip.s_addr
+
+template ip4SetWord() {.dirty.} =
+  ip.s_addr = w
+
+type IP4EndpointImpl {.requiresInit, borrow: `.`.} = distinct Sockaddr_in
+
+template ip4InitEndpoint() {.dirty.} =
+  result = IP4EndpointImpl:
+    Sockaddr_in(
+      sin_family: AF_INET.TSa_Family,
+      sin_addr: InAddr(ip),
+      sin_port: toBE(port.uint16)
+    )
+
+template ip4EndpointAddr() {.dirty.} =
+  result = IP4 e.sin_addr
+
+template ip4EndpointPort() {.dirty.} =
+  result = Port fromBE(e.sin_port)

--- a/src/sys/private/addresses_windows.nim
+++ b/src/sys/private/addresses_windows.nim
@@ -1,0 +1,37 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+import syscall/winim/winim/core as wincore except Handle
+
+type
+  IP4Impl {.borrow: `.`.} = distinct InAddr
+  IP6Impl {.borrow: `.`.} = distinct In6Addr
+
+template ip4Word() {.dirty.} =
+  result = cast[uint32](ip.S_addr)
+
+template ip4SetWord() {.dirty.} =
+  ip.S_addr = cast[int32](w)
+
+type IP4EndpointImpl {.requiresInit, borrow: `.`.} = distinct Sockaddr_in
+
+template ip4InitEndpoint() {.dirty.} =
+  result = IP4EndpointImpl:
+    sockaddr_in(
+      sin_family: AF_INET,
+      sin_addr: InAddr(ip),
+      sin_port: toBE(port.uint16)
+    )
+
+template ip4EndpointAddr() {.dirty.} =
+  result = IP4 e.sin_addr
+
+template ip4EndpointPort() {.dirty.} =
+  result = Port fromBE(e.sin_port)
+
+

--- a/src/sys/private/ioqueue_bsd.nim
+++ b/src/sys/private/ioqueue_bsd.nim
@@ -151,6 +151,7 @@ template waitEventImpl() {.dirty.} =
 
 template unregisterImpl() {.dirty.} =
   if not eq.initialized: return
+  let fd = FD fd # Normalize FDs into FD
 
   # If the FD is in the waiter list
   if fd in eq.waiters:

--- a/src/sys/private/ioqueue_linux.nim
+++ b/src/sys/private/ioqueue_linux.nim
@@ -157,6 +157,7 @@ template waitEventImpl() {.dirty.} =
 
 template unregisterImpl() {.dirty.} =
   if not eq.initialized: return
+  let fd = fd.FD # Converts the `fd` parameter to `FD`
 
   # If the FD is in the waiter list
   if fd in eq.waiters:

--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -102,7 +102,7 @@ template ip4Word() {.dirty.} =
 template ip4SetWord() {.dirty.} =
   ip.s_addr = w
 
-type IP4EndpointImpl {.borrow: `.`.} = distinct Sockaddr_in
+type IP4EndpointImpl {.requiresInit, borrow: `.`.} = distinct Sockaddr_in
 
 template ip4InitEndpoint() {.dirty.} =
   result = IP4EndpointImpl:

--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -93,32 +93,6 @@ template asyncWriteImpl() {.dirty.} =
       return written
 
 type
-  IP4Impl {.borrow: `.`.} = distinct InAddr
-  IP6Impl {.borrow: `.`.} = distinct In6Addr
-
-template ip4Word() {.dirty.} =
-  result = ip.s_addr
-
-template ip4SetWord() {.dirty.} =
-  ip.s_addr = w
-
-type IP4EndpointImpl {.requiresInit, borrow: `.`.} = distinct Sockaddr_in
-
-template ip4InitEndpoint() {.dirty.} =
-  result = IP4EndpointImpl:
-    Sockaddr_in(
-      sin_family: AF_INET.TSa_Family,
-      sin_addr: InAddr(ip),
-      sin_port: toBE(port.uint16)
-    )
-
-template ip4EndpointAddr() {.dirty.} =
-  result = IP4 e.sin_addr
-
-template ip4EndpointPort() {.dirty.} =
-  result = Port fromBE(e.sin_port)
-
-type
   ResolverResultImpl* = object
     info: ptr AddrInfo
 

--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -31,10 +31,10 @@ proc makeSocket(domain, typ, proto: cint, flags: set[SockFlag] = {}): Handle[Soc
   when defined(macosx):
     # OSX does not support setting cloexec and nonblock on socket creation, so
     # it has to be done here.
-    setInheritable(result.get, false)
+    setInheritable(sock.get, false)
 
     if sfNonBlock in flags:
-      setBlocking(result.get, false)
+      setBlocking(sock.get, false)
 
   result = sock
 

--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -1,0 +1,373 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+import syscall/posix
+import errors
+
+type
+  SockFlag = enum
+    ## Flags used for makeSocket
+    sfNonBlock
+
+proc makeSocket(domain, typ, proto: cint, flags: set[SockFlag] = {}): SocketFD =
+  var stype = typ
+
+  when not defined(macosx):
+    # OSX does not support setting cloexec and nonblock on the same socket
+    stype = stype or SOCK_CLOEXEC
+
+    if sfNonBlock in flags:
+      stype = stype or SOCK_NONBLOCK
+
+  result = SocketFD socket(domain, stype, proto)
+  posixChk cint(result)
+
+  # In the case where any of the following steps fail, we want to close
+  # the FD to prevent leaks.
+  var success = false
+  defer:
+    if not success:
+      close result
+
+  when defined(macosx):
+    setInheritable(result, false)
+
+    if sfNonBlock in flags:
+      setBlocking(result, false)
+
+  success = true
+
+template readImpl() {.dirty.} =
+  let bytesRead = retryOnEIntr:
+    if b.len > 0:
+      read(s.fd.cint, addr b[0], b.len)
+    else:
+      read(s.fd.cint, nil, 0)
+
+  if bytesRead == -1:
+    raise newIOError(0, errno, $Error.Read)
+
+  result = bytesRead
+
+template writeImpl() {.dirty.} =
+  let written = retryOnEIntr:
+    if b.len > 0:
+      write(s.fd.cint, cast[ptr UncheckedArray[byte]](unsafeAddr b[0]), b.len)
+    else:
+      write(s.fd.cint, nil, 0)
+
+  if written == -1:
+    raise newIOError(0, errno, $Error.Write)
+
+  result = written
+
+template asyncReadImpl() {.dirty.} =
+  while true:
+    let bytesRead = retryOnEIntr: read(s.fd.cint, buf, bufLen)
+
+    if bytesRead == -1:
+      # On "no data yet" signal
+      if errno == EAGAIN or errno == EWOULDBLOCK:
+        # Wait until there is data
+        wait(s.fd, Event.Read)
+      else:
+        raise newIOError(0, errno, $Error.Read)
+    else:
+      # Done
+      return bytesRead
+
+template asyncWriteImpl() {.dirty.} =
+  while true:
+    let written = retryOnEIntr: write(s.fd.cint, buf, bufLen)
+
+    if written == -1:
+      # On "no buffer space yet" signal
+      if errno == EAGAIN or errno == EWOULDBLOCK:
+        # Wait until there is space
+        wait(s.fd, Event.Write)
+      else:
+        raise newIOError(0, errno, $Error.Write)
+    else:
+      # Done
+      return written
+
+type
+  IP4Impl {.borrow: `.`.} = distinct InAddr
+  IP6Impl {.borrow: `.`.} = distinct In6Addr
+
+template ip4Word() {.dirty.} =
+  result = ip.s_addr
+
+template ip4SetWord() {.dirty.} =
+  ip.s_addr = w
+
+type IP4EndpointImpl {.borrow: `.`.} = distinct Sockaddr_in
+
+template ip4InitEndpoint() {.dirty.} =
+  result = IP4EndpointImpl:
+    Sockaddr_in(
+      sin_family: AF_INET.TSa_Family,
+      sin_addr: InAddr(ip),
+      sin_port: toBE(port.uint16)
+    )
+
+template ip4EndpointAddr() {.dirty.} =
+  result = IP4 e.sin_addr
+
+template ip4EndpointPort() {.dirty.} =
+  result = Port fromBE(e.sin_port)
+
+type
+  ResolverResultImpl* = object
+    info: ptr AddrInfo
+
+proc `=destroy`(r: var ResolverResultImpl) =
+  if r.info != nil:
+    freeaddrinfo(r.info)
+    r.info = nil
+
+template ip4Resolve() {.dirty.} =
+  result = new ResolverResultImpl
+
+  let hints = AddrInfo(
+    ai_family: AF_INET,
+    ai_flags: AI_NUMERICSERV or AI_ADDRCONFIG
+  )
+
+  let err = getaddrinfo(
+    cstring(host),
+    if port == PortNone: nil else: cstring($port),
+    unsafeAddr hints,
+    result.info
+  )
+   
+  if err != 0:
+    if err == EAI_SYSTEM:
+      raise newOSError(errno, $Error.Resolve)
+    else:
+      let ex = newException(ResolverError, "")
+      ex.errorCode = err
+      ex.msg = $gai_strerror(err)
+      raise ex
+
+template resolvedItems() {.dirty.} =
+  var info = r.info
+  while info != nil:
+    if info.ai_addr != nil:
+      if info.ai_addr.sa_family == AF_INET.TSa_Family:
+        yield cast[ptr IP4Endpoint](info.ai_addr)[]
+
+    info = info.ai_next
+
+template tcpConnect() {.dirty.} =
+  let sock = makeSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+
+  # Close the socket if the connection attempt was unsuccessful
+  var success = false
+  defer:
+    if not success:
+      close sock
+
+  posixChk connect(
+    SocketHandle(sock),
+    cast[ptr Sockaddr](unsafeAddr endpoint),
+    SockLen sizeof(endpoint)
+  ):
+    $Error.Connect
+
+  result = Conn[TCP] newSocket(sock)
+  success = true
+
+template tcpAsyncConnect() {.dirty.} =
+  let sock = makeSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, {sfNonBlock})
+
+  # Close the socket if the connection attempt was unsuccessful
+  var success = false
+  defer:
+    if not success:
+      close sock
+
+  if connect(SocketHandle(sock), cast[ptr Sockaddr](unsafeAddr endpoint), SockLen sizeof(endpoint)) == -1:
+    # The connection is happening asynchronously
+    if errno == EINPROGRESS:
+      # Wait until the socket is writable, which is when it is "connected" (see connect(3p)).
+      wait(sock, Event.Write)
+
+      # Examine the SO_ERROR in SOL_SOCKET for any error happened during the asynchronous operation.
+      var
+        error: cint
+        errorLen = SockLen sizeof(error)
+      posixChk getsockopt(
+        SocketHandle(sock), SOL_SOCKET, SO_ERROR, addr error, addr errorLen
+      ):
+        $Error.Connect
+
+      assert errorLen == SockLen sizeof(error):
+        "The length of the error does not match nim-sys assumption. This is a nim-sys bug."
+
+      # Raise the error if any was found.
+      if error != 0:
+        raise newOSError(error, $Error.Connect)
+    else:
+      posixChk -1, $Error.Connect
+
+  result = AsyncConn[TCP] newAsyncSocket(sock)
+  success = true
+
+template tcpListen() {.dirty.} =
+  let sock = makeSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+
+  # Close the socket if the attempt was unsuccessful
+  var success = false
+  defer:
+    if not success:
+      close sock
+
+  # Bind the address to the socket
+  posixChk bindSocket(
+    SocketHandle sock, cast[ptr SockAddr](unsafeAddr endpoint), SockLen sizeof(endpoint)
+  ):
+    $Error.Listen
+
+  # Mark the socket as accepting connections
+  posixChk listen(SocketHandle sock, 0), $Error.Listen
+  
+  result = Listener[TCP] newSocket(sock)
+  success = true
+
+template tcpAsyncListen() {.dirty.} =
+  let sock = makeSocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, {sfNonBlock})
+
+  # Close the socket if the attempt was unsuccessful
+  var success = false
+  defer:
+    if not success:
+      close sock
+
+  if bindSocket(
+    SocketHandle sock, cast[ptr SockAddr](unsafeAddr endpoint), SockLen sizeof(endpoint)
+  ) == -1:
+    # While this is shown in the POSIX manual to be a possible error value, in
+    # practice it appears that not many (if any) OS actually implements bind
+    # this way (judging from their manuals).
+    if errno == EINPROGRESS:
+      # Wait until the socket is readable, which is when it is "bound" (see bind(3p)).
+      wait(sock, Event.Read)
+
+      # Examine the SO_ERROR in SOL_SOCKET for any error happened during the asynchronous operation.
+      var
+        error: cint
+        errorLen = SockLen sizeof(error)
+      posixChk getsockopt(
+        SocketHandle(sock), SOL_SOCKET, SO_ERROR, addr error, addr errorLen
+      ):
+        $Error.Connect
+
+      assert errorLen == SockLen sizeof(error):
+        "The length of the error does not match nim-sys assumption. This is a nim-sys bug."
+
+      # Raise the error if any was found.
+      if error != 0:
+        raise newOSError(error, $Error.Listen)
+
+  # Mark the socket as accepting connections
+  posixChk listen(SocketHandle sock, 0), $Error.Listen
+  
+  result = AsyncListener[TCP] newAsyncSocket(sock)
+  success = true
+
+template tcpAccept() {.dirty.} =
+  var remoteLen = SockLen sizeof(result.remote)
+
+  let conn = SocketFD:
+    when not defined(macosx):
+      accept4(l.fd.SocketHandle, cast[ptr SockAddr](addr result.remote), addr remoteLen, SOCK_CLOEXEC)
+    else:
+      accept(l.fd.SocketHandle, cast[ptr SockAddr](addr result.remote), addr remoteLen)
+
+  posixChk cint(conn), $Error.Accept
+
+  # On failure close the connection
+  var success = false
+  defer:
+    if not success:
+      close conn
+
+  assert remoteLen == SockLen sizeof(result.remote):
+    "The length of the endpoint structure does not match assumption. This is a nim-sys bug."
+  assert result.remote.sin_family == AF_INET.TSa_Family:
+    "The address is not IPv4. This is a nim-sys bug."
+
+  when defined(macosx):
+    # OSX does not support the accept4 interface, so we have to set the
+    # properties manually.
+    conn.setInheritable(false)
+
+  result.conn = Conn[TCP] newSocket(conn)
+  success = true
+
+template tcpAsyncAccept() {.dirty.} =
+  var
+    conn = SocketFD InvalidFD
+    remoteLen: SockLen
+
+  # Loop until we get a connection
+  while true:
+    remoteLen = SockLen sizeof(result.remote)
+
+    conn = SocketFD:
+      when not defined(macosx):
+        accept4(l.fd.SocketHandle, cast[ptr SockAddr](addr result.remote), addr remoteLen, SOCK_CLOEXEC or SOCK_NONBLOCK)
+      else:
+        accept(l.fd.SocketHandle, cast[ptr SockAddr](addr result.remote), addr remoteLen)
+
+    if conn == InvalidFD:
+      # If the socket signals that no connections are pending
+      if errno == EAGAIN or errno == EWOULDBLOCK:
+        # Wait until some shows up then try again
+        wait(l.fd, Event.Read)
+      else:
+        posixChk -1, $Error.Accept
+    else:
+      # We got a connection
+      break
+
+  # On failure close the connection
+  var success = false
+  defer:
+    if not success:
+      close conn
+
+  assert remoteLen == SockLen sizeof(result.remote):
+    "The length of the endpoint structure does not match assumption. This is a nim-sys bug."
+  assert result.remote.sin_family == AF_INET.TSa_Family:
+    "The address is not IPv4. This is a nim-sys bug."
+
+  when defined(macosx):
+    # OSX does not support the accept4 interface, so we have to set the
+    # properties manually.
+    conn.setInheritable(false)
+    conn.setBlocking(false)
+
+  result.conn = AsyncConn[TCP] newSocket(conn)
+  success = true
+
+template tcpLocalEndpoint() {.dirty.} =
+  var endpointLen = SockLen sizeof(result)
+
+  posixChk getsockname(
+    SocketHandle l.fd,
+    cast[ptr SockAddr](addr result),
+    addr endpointLen
+  ):
+    $Error.LocalEndpoint
+
+  assert endpointLen == SockLen sizeof(result):
+    "The length of the endpoint structure does not match assumption. This is a nim-sys bug."
+  assert result.sin_family == TSa_Family(AF_INET):
+    "The address is not IPv4. This is a nim-sys bug."

--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -274,6 +274,8 @@ template tcpAsyncListen() {.dirty.} =
       # Raise the error if any was found.
       if error != 0:
         raise newOSError(error, $Error.Listen)
+    else:
+      posixChk -1, $Error.Listen
 
   # Mark the socket as accepting connections
   posixChk listen(SocketHandle sock, 0), $Error.Listen

--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -31,10 +31,10 @@ proc makeSocket(domain, typ, proto: cint, flags: set[SockFlag] = {}): Handle[Soc
   when defined(macosx):
     # OSX does not support setting cloexec and nonblock on socket creation, so
     # it has to be done here.
-    setInheritable(result, false)
+    setInheritable(result.get, false)
 
     if sfNonBlock in flags:
-      setBlocking(result, false)
+      setBlocking(result.get, false)
 
   result = sock
 

--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -214,7 +214,7 @@ template tcpAsyncConnect() {.dirty.} =
       if error != 0:
         raise newOSError(error, $Error.Connect)
     else:
-      posixChk -1, $Error.Connect
+      raise newOSError(errno, $Error.Connect)
 
   result = AsyncConn[TCP] newAsyncSocket(sock)
   success = true
@@ -275,7 +275,7 @@ template tcpAsyncListen() {.dirty.} =
       if error != 0:
         raise newOSError(error, $Error.Listen)
     else:
-      posixChk -1, $Error.Listen
+      raise newOSError(errno, $Error.Listen)
 
   # Mark the socket as accepting connections
   posixChk listen(SocketHandle sock, 0), $Error.Listen
@@ -334,7 +334,7 @@ template tcpAsyncAccept() {.dirty.} =
         # Wait until some shows up then try again
         wait(l.fd, Event.Read)
       else:
-        posixChk -1, $Error.Accept
+        raise newOSError(errno, $Error.Accept)
     else:
       # We got a connection
       break

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -18,10 +18,17 @@ func ioSize(x: int): ULONG {.inline.} =
 
 template readImpl() {.dirty.} =
   var
-    buf = WSABuf(
-      len: ioSize(b.len),
-      buf: addr b[0]
-    )
+    buf =
+      if b.len > 0:
+        WSABuf(
+          len: ioSize(b.len),
+          buf: cast[ptr char](addr b[0])
+        )
+      else:
+        WSABuf(
+          len: 0,
+          buf: nil
+        )
     bytesRead: DWORD
     flags: DWORD # This is ignored for now
 
@@ -34,10 +41,17 @@ template readImpl() {.dirty.} =
 
 template writeImpl() {.dirty.} =
   var
-    buf = WSABuf(
-      len: ioSize(b.len),
-      buf: unsafeAddr b[0]
-    )
+    buf =
+      if b.len > 0:
+        WSABuf(
+          len: ioSize(b.len),
+          buf: cast[ptr char](unsafeAddr b[0])
+        )
+      else:
+        WSABuf(
+          len: 0,
+          buf: nil
+        )
     bytesWritten: DWORD
 
   if WSASend(
@@ -56,7 +70,7 @@ template asyncReadImpl() {.dirty.} =
     errorCode: DWORD = ErrorSuccess
     buf = WSABuf(
       len: ioSize(bufLen),
-      buf: cast[cstring](buf)
+      buf: cast[ptr char](buf)
     )
     bytesRead: DWORD
     flags: DWORD # This is ignored for now
@@ -99,7 +113,7 @@ template asyncWriteImpl() {.dirty.} =
     errorCode: DWORD = ErrorSuccess
     buf = WSABuf(
       len: ioSize(bufLen),
-      buf: cast[cstring](buf)
+      buf: cast[ptr char](buf)
     )
     bytesWritten: DWORD
 

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -247,11 +247,11 @@ template tcpConnect() {.dirty.} =
     SocketFD:
       WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, toWSAFlags({}))
 
-  if sock.get == InvalidFD:
+  if sock.fd == InvalidFD:
     raise newOSError(WSAGetLastError(), $Error.Connect)
 
   if connect(
-    wincore.Socket(sock.get),
+    wincore.Socket(sock.fd),
     cast[ptr sockaddr](unsafeAddr endpoint),
     cint sizeof(endpoint)
   ) == SocketError:
@@ -337,12 +337,12 @@ template tcpListen() {.dirty.} =
     SocketFD:
       WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, toWSAFlags({}))
 
-  if sock.get == InvalidFD:
+  if sock.fd == InvalidFD:
     raise newOSError(WSAGetLastError(), $Error.Listen)
 
   # Bind the address to the socket
   if `bind`(
-    wincore.Socket(sock.get),
+    wincore.Socket(sock.fd),
     cast[ptr sockaddr](unsafeAddr endpoint),
     cint sizeof(endpoint)
   ) == SocketError:
@@ -350,7 +350,7 @@ template tcpListen() {.dirty.} =
 
   # Mark the socket as accepting connections
   if listen(
-    wincore.Socket(sock.get), backlog.get(SOMAXCONN).cint
+    wincore.Socket(sock.fd), backlog.get(SOMAXCONN).cint
   ) == SocketError:
     raise newOSError(WSAGetLastError(), $Error.Listen)
 
@@ -361,12 +361,12 @@ template tcpAsyncListen() {.dirty.} =
     SocketFD:
       WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, toWSAFlags({sfOverlapped}))
 
-  if sock.get == InvalidFD:
+  if sock.fd == InvalidFD:
     raise newOSError(WSAGetLastError(), $Error.Listen)
 
   # Bind the address to the socket
   if `bind`(
-    wincore.Socket(sock.get),
+    wincore.Socket(sock.fd),
     cast[ptr sockaddr](unsafeAddr endpoint),
     cint sizeof(endpoint)
   ) == SocketError:
@@ -374,7 +374,7 @@ template tcpAsyncListen() {.dirty.} =
 
   # Mark the socket as accepting connections
   if listen(
-    wincore.Socket(sock.get), backlog.get(SOMAXCONN).cint
+    wincore.Socket(sock.fd), backlog.get(SOMAXCONN).cint
   ) == SocketError:
     raise newOSError(WSAGetLastError(), $Error.Listen)
 
@@ -402,7 +402,7 @@ template acceptCommon(listener: SocketFD, conn: var Handle[SocketFD],
           else:
             {}
 
-  if conn.get == InvalidFD:
+  if conn.fd == InvalidFD:
     raise newOSError(WSAGetLastError(), $Error.Accept)
 
   var
@@ -417,7 +417,7 @@ template acceptCommon(listener: SocketFD, conn: var Handle[SocketFD],
 
   if AcceptEx(
     wincore.Socket(listener),
-    wincore.Socket(conn.get),
+    wincore.Socket(conn.fd),
     addr buf[0],
     0,
     AcceptExLocalLength,
@@ -481,7 +481,7 @@ template acceptCommon(listener: SocketFD, conn: var Handle[SocketFD],
   # socket.
   var listenerSock = listener
   if setsockopt(
-    wincore.Socket(conn.get),
+    wincore.Socket(conn.fd),
     SolSocket,
     SoUpdateAcceptContext,
     cast[cstring](addr listenerSock),
@@ -536,7 +536,7 @@ proc initWinsock() =
     SocketFD:
       WSASocketW(AF_INET, SOCK_STREAM, 0, nil, 0, toWSAFlags({}))
 
-  if dummy.get == InvalidFD:
+  if dummy.fd == InvalidFD:
     raise newOSError(WSAGetLastError(), "Could not initialize sys/sockets")
 
   # Obtain the function pointer for ConnectEx
@@ -544,7 +544,7 @@ proc initWinsock() =
     fnGuid = WSAID_CONNECTEX
     bytesReturned: DWORD
   if WSAIoctl(
-    wincore.Socket(dummy.get),
+    wincore.Socket(dummy.fd),
     SIO_GET_EXTENSION_FUNCTION_POINTER,
     addr fnGuid,
     DWORD sizeof(fnGuid),

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -149,32 +149,6 @@ template asyncWriteImpl() {.dirty.} =
   result = bytesWritten
 
 type
-  IP4Impl {.borrow: `.`.} = distinct InAddr
-  IP6Impl {.borrow: `.`.} = distinct In6Addr
-
-template ip4Word() {.dirty.} =
-  result = cast[uint32](ip.S_addr)
-
-template ip4SetWord() {.dirty.} =
-  ip.S_addr = cast[int32](w)
-
-type IP4EndpointImpl {.requiresInit, borrow: `.`.} = distinct Sockaddr_in
-
-template ip4InitEndpoint() {.dirty.} =
-  result = IP4EndpointImpl:
-    sockaddr_in(
-      sin_family: AF_INET,
-      sin_addr: InAddr(ip),
-      sin_port: toBE(port.uint16)
-    )
-
-template ip4EndpointAddr() {.dirty.} =
-  result = IP4 e.sin_addr
-
-template ip4EndpointPort() {.dirty.} =
-  result = Port fromBE(e.sin_port)
-
-type
   ResolverResultImpl* = object
     info: ptr AddrInfoW
 
@@ -389,7 +363,7 @@ const
   AcceptExBufferLength = AcceptExLocalLength + AcceptExRemoteLength
 
 template acceptCommon(listener: SocketFD, conn: var Handle[SocketFD],
-                      remote: var IP4EndpointImpl, overlapped: static bool) =
+                      remote: var IP4Endpoint, overlapped: static bool) =
   # Common parts for dealing with AcceptEx, `overlapped` dictates whether the
   # operation should be done in an overlapped manner and yields an overlapped
   # socket.
@@ -475,7 +449,7 @@ template acceptCommon(listener: SocketFD, conn: var Handle[SocketFD],
     "The address is not IPv4. This is a nim-sys bug."
 
   # Copy the remote address
-  remote = cast[ptr IP4EndpointImpl](remoteAddr)[]
+  remote = cast[ptr IP4Endpoint](remoteAddr)[]
 
   # Update the connection attributes so that other functions can be used on the
   # socket.

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -158,7 +158,7 @@ template ip4Word() {.dirty.} =
 template ip4SetWord() {.dirty.} =
   ip.S_addr = cast[int32](w)
 
-type IP4EndpointImpl {.borrow: `.`.} = distinct Sockaddr_in
+type IP4EndpointImpl {.requiresInit, borrow: `.`.} = distinct Sockaddr_in
 
 template ip4InitEndpoint() {.dirty.} =
   result = IP4EndpointImpl:

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -35,7 +35,7 @@ template readImpl() {.dirty.} =
   if WSARecv(
     wincore.Socket(s.fd), addr buf, 1, addr bytesRead, addr flags, nil, nil
   ) == SocketError:
-    raise newOSError(WSAGetLastError(), $Error.Read)
+    raise newIOError(bytesRead, WSAGetLastError(), $Error.Read)
 
   result = bytesRead
 
@@ -57,7 +57,7 @@ template writeImpl() {.dirty.} =
   if WSASend(
     wincore.Socket(s.fd), addr buf, 1, addr bytesWritten, 0, nil, nil
   ) == SocketError:
-    raise newOSError(WSAGetLastError(), $Error.Write)
+    raise newIOError(bytesWritten, WSAGetLastError(), $Error.Write)
 
   result = bytesWritten
 
@@ -100,7 +100,7 @@ template asyncReadImpl() {.dirty.} =
 
   # Raise errors on failure.
   if errorCode != ErrorSuccess:
-    raise newOSError(errorCode, $Error.Read)
+    raise newIOError(bytesRead, errorCode, $Error.Read)
 
   result = bytesRead
 
@@ -144,7 +144,7 @@ template asyncWriteImpl() {.dirty.} =
 
   # Raise errors on failure.
   if errorCode != ErrorSuccess:
-    raise newOSError(errorCode, $Error.Write)
+    raise newIOError(bytesWritten, errorCode, $Error.Write)
 
   result = bytesWritten
 

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -14,7 +14,7 @@ import errors
 
 func ioSize(x: int): ULONG {.inline.} =
   ## Clamp `x` to the IO size supported by Winsock.
-  DWORD min(x, high(ULONG))
+  ULONG min(x, high(ULONG))
 
 template readImpl() {.dirty.} =
   var

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -1,0 +1,545 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+from std/os import osErrorMsg, OSErrorCode
+import syscall/winim/winim/core as wincore except Handle
+import syscall/winim/winim/winstr
+import ".."/ioqueue/iocp
+import errors
+
+func ioSize(x: int): ULONG {.inline.} =
+  ## Clamp `x` to the IO size supported by Winsock.
+  DWORD min(x, high(ULONG))
+
+template readImpl() {.dirty.} =
+  var
+    buf = WSABuf(
+      len: ioSize(b.len),
+      buf: addr b[0]
+    )
+    bytesRead: DWORD
+    flags: DWORD # This is ignored for now
+
+  if WSARecv(
+    wincore.Socket(s.fd), addr buf, 1, addr bytesRead, addr flags, nil, nil
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Read)
+
+  result = bytesRead
+
+template writeImpl() {.dirty.} =
+  var
+    buf = WSABuf(
+      len: ioSize(b.len),
+      buf: unsafeAddr b[0]
+    )
+    bytesWritten: DWORD
+
+  if WSASend(
+    wincore.Socket(s.fd), addr buf, 1, addr bytesWritten, 0, nil, nil
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Write)
+
+  result = bytesWritten
+
+template asyncReadImpl() {.dirty.} =
+  # Register the FD as persistent. This is required for IOCP operations.
+  persist(s.fd)
+
+  let overlapped = new Overlapped
+  var
+    errorCode: DWORD = ErrorSuccess
+    buf = WSABuf(
+      len: ioSize(bufLen),
+      buf: cast[cstring](buf)
+    )
+    bytesRead: DWORD
+    flags: DWORD # This is ignored for now
+
+  if WSARecv(
+    wincore.Socket(s.fd), addr buf, 1, addr bytesRead, addr flags,
+    cast[ptr Overlapped](addr overlapped[]), nil
+  ) == SocketError:
+    errorCode = WSAGetLastError()
+
+  # If the operation is running in the background
+  if errorCode == WSAIoPending:
+    # Wait until the operation completes
+    wait(s.fd, overlapped)
+
+    # Obtain the result of the operation
+    if WSAGetOverlappedResult(
+      wincore.Socket(s.fd),
+      cast[ptr Overlapped](addr overlapped[]),
+      addr bytesRead,
+      fWait = wincore.False,
+      addr flags
+    ) == wincore.False:
+      errorCode = WSAGetLastError()
+    else:
+      errorCode = ErrorSuccess
+
+  # Raise errors on failure.
+  if errorCode != ErrorSuccess:
+    raise newOSError(errorCode, $Error.Read)
+
+  result = bytesRead
+
+template asyncWriteImpl() {.dirty.} =
+  # Register the FD as persistent. This is required for IOCP operations.
+  persist(s.fd)
+
+  let overlapped = new Overlapped
+  var
+    errorCode: DWORD = ErrorSuccess
+    buf = WSABuf(
+      len: ioSize(bufLen),
+      buf: cast[cstring](buf)
+    )
+    bytesWritten: DWORD
+
+  if WSASend(
+    wincore.Socket(s.fd), addr buf, 1, addr bytesWritten, 0,
+    cast[ptr Overlapped](addr overlapped[]), nil
+  ) == SocketError:
+    errorCode = WSAGetLastError()
+
+  # If the operation is running in the background
+  if errorCode == WSAIoPending:
+    # Wait until the operation completes
+    wait(s.fd, overlapped)
+
+    # This is not used for writes, but WSAGetOverlappedResult demands it
+    var flags: DWORD
+    # Obtain the result of the operation
+    if WSAGetOverlappedResult(
+      wincore.Socket(s.fd),
+      cast[ptr Overlapped](addr overlapped[]),
+      addr bytesWritten,
+      fWait = wincore.False,
+      addr flags
+    ) == wincore.False:
+      errorCode = WSAGetLastError()
+    else:
+      errorCode = ErrorSuccess
+
+  # Raise errors on failure.
+  if errorCode != ErrorSuccess:
+    raise newOSError(errorCode, $Error.Write)
+
+  result = bytesWritten
+
+type
+  IP4Impl {.borrow: `.`.} = distinct InAddr
+  IP6Impl {.borrow: `.`.} = distinct In6Addr
+
+template ip4Word() {.dirty.} =
+  result = cast[uint32](ip.S_addr)
+
+template ip4SetWord() {.dirty.} =
+  ip.S_addr = cast[int32](w)
+
+type IP4EndpointImpl {.borrow: `.`.} = distinct Sockaddr_in
+
+template ip4InitEndpoint() {.dirty.} =
+  result = IP4EndpointImpl:
+    sockaddr_in(
+      sin_family: AF_INET,
+      sin_addr: InAddr(ip),
+      sin_port: toBE(port.uint16)
+    )
+
+template ip4EndpointAddr() {.dirty.} =
+  result = IP4 e.sin_addr
+
+template ip4EndpointPort() {.dirty.} =
+  result = Port fromBE(e.sin_port)
+
+type
+  ResolverResultImpl* = object
+    info: ptr AddrInfoW
+
+proc `=destroy`(r: var ResolverResultImpl) =
+  if r.info != nil:
+    FreeAddrInfoW(r.info)
+    r.info = nil
+
+template ip4Resolve() {.dirty.} =
+  result = new ResolverResultImpl
+
+  let hints = AddrInfoW(
+    ai_flags: AI_ADDRCONFIG,
+    ai_family: AF_INET
+  )
+
+  let err = GetAddrInfoW(
+    # Convert host to wide string then pass the pointer
+    &L(host),
+    &L($port),
+    unsafeAddr hints,
+    addr result.info
+  )
+
+  if err != ErrorSuccess:
+    case err
+    # Since Windows use the same error namespace for the resolver and system
+    # errors, they are distingused by the fact that they are referenced in MS
+    # documentation:
+    # https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfow
+    of WSANotEnoughMemory, WSAEAFNOSUPPORT, WSAEINVAL, WSAESOCKTNOSUPPORT,
+       WSAHostNotFound, WSANoData, WSANoRecovery, WSATryAgain, WSATypeNotFound:
+      let ex = newException(ResolverError, "")
+      ex.errorCode = err
+      ex.msg = osErrorMsg(OSErrorCode err)
+      raise ex
+    else:
+      raise newOSError(err, $Error.Resolve)
+
+template resolvedItems() {.dirty.} =
+  var info = r.info
+  while info != nil:
+    if info.ai_addr != nil:
+      if info.ai_addr.sa_family == AF_INET:
+        yield cast[ptr IP4Endpoint](info.ai_addr)[]
+
+    info = info.ai_next
+
+const WSAFlagNoHandleInherit = 0x80.DWORD
+  ## Create a non-inheritable socket.
+  ##
+  ## TODO: upstream this into winim.
+
+type
+  SockFlag = enum
+    sfOverlapped
+
+func toWSAFlags(flags: set[SockFlag]): DWORD {.inline.} =
+  ## Turns `flags` into a DWORD value that can be passed to `WSASocket`
+  ##
+  ## * Handle inheritance is disabled by default
+  result = WSAFlagNoHandleInherit
+  if sfOverlapped in flags:
+    result = result or WSAFlagOverlapped
+
+var ConnectEx: LPFN_CONNECTEX
+
+template tcpConnect() {.dirty.} =
+  let sock = initHandle:
+    SocketFD:
+      WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, toWSAFlags({}))
+
+  if sock.get == InvalidFD:
+    raise newOSError(WSAGetLastError(), $Error.Connect)
+
+  if connect(
+    wincore.Socket(sock.get),
+    cast[ptr sockaddr](unsafeAddr endpoint),
+    cint sizeof(endpoint)
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Connect)
+
+  result = Conn[TCP] newSocket(sock)
+
+template tcpAsyncConnect() {.dirty.} =
+  var sock = initHandle:
+    SocketFD:
+      WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, toWSAFlags({sfOverlapped}))
+
+  if sock.get == InvalidFD:
+    raise newOSError(WSAGetLastError(), $Error.Connect)
+
+  # A local endpoint has to be bound into `sock` before ConnectEx can be used.
+  if `bind`(
+    wincore.Socket(sock.get),
+    cast[ptr sockaddr](unsafeAddr endpoint),
+    cint sizeof(endpoint)
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Listen)
+
+  # Register `sock` into IOCP
+  persist(sock.get)
+
+  let overlapped = new Overlapped
+  var errorCode: DWORD = ErrorSuccess
+  if ConnectEx(
+    wincore.Socket(sock.get),
+    cast[ptr sockaddr](unsafeAddr endpoint),
+    cint sizeof(endpoint),
+    nil,
+    0,
+    nil,
+    cast[ptr Overlapped](addr overlapped[])
+  ) == SocketError:
+    errorCode = WSAGetLastError()
+
+  if errorCode == WSAIoPending:
+    # Wait for the operation to complete
+    wait(sock, overlapped)
+
+    # These are required by WSAGetOverlappedResult(), but unused in this
+    # situation.
+    var transferred, flags: DWORD
+    if WSAGetOverlappedResult(
+      wincore.Socket(sock.get),
+      cast[ptr Overlapped](addr overlapped[]),
+      addr transferred,
+      fWait = wincore.False,
+      addr flags
+    ) == SocketError:
+      errorCode = WSAGetLastError()
+    else:
+      errorCode = ErrorSuccess
+
+  if errorCode != ErrorSuccess:
+    raise newOSError(errorCode, $Error.Connect)
+
+  # After ConnectEx, SO_UPDATE_CONNECT_CONTEXT has to be set for shutdown,
+  # getpeername, getsockname to work.
+  #
+  # https://docs.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options
+  if setsockopt(
+    wincore.Socket(sock.get),
+    SolSocket,
+    SoUpdateConnectContext,
+    nil,
+    0
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Connect)
+
+  # A move has to be done in CPS
+  result = AsyncConn[TCP] newAsyncSocket(move sock)
+
+template tcpListen() {.dirty.} =
+  var sock = initHandle:
+    SocketFD:
+      WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, toWSAFlags({}))
+
+  if sock.get == InvalidFD:
+    raise newOSError(WSAGetLastError(), $Error.Listen)
+
+  # Bind the address to the socket
+  if `bind`(
+    wincore.Socket(sock.get),
+    cast[ptr sockaddr](unsafeAddr endpoint),
+    cint sizeof(endpoint)
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Listen)
+
+  # Mark the socket as accepting connections
+  if listen(
+    wincore.Socket(sock.get), backlog.get(SOMAXCONN).cint
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Listen)
+
+  result = Listener[TCP] newSocket(sock)
+
+template tcpAsyncListen() {.dirty.} =
+  var sock = initHandle:
+    SocketFD:
+      WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0, toWSAFlags({sfOverlapped}))
+
+  if sock.get == InvalidFD:
+    raise newOSError(WSAGetLastError(), $Error.Listen)
+
+  # Bind the address to the socket
+  if `bind`(
+    wincore.Socket(sock.get),
+    cast[ptr sockaddr](unsafeAddr endpoint),
+    cint sizeof(endpoint)
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Listen)
+
+  # Mark the socket as accepting connections
+  if listen(
+    wincore.Socket(sock.get), backlog.get(SOMAXCONN).cint
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Listen)
+
+  result = AsyncListener[TCP] newAsyncSocket(move sock)
+
+{.warning: "cps issue workaround; see https://github.com/nim-works/cps/issues/260".}
+const
+  # The extra 16 bytes is required by the API. SockaddrStorage is used
+  # because its the largest possible size.
+  AcceptExLocalLength = sizeof(SockaddrStorage) + 16
+  AcceptExRemoteLength = sizeof(SockaddrStorage) + 16
+  AcceptExBufferLength = AcceptExLocalLength + AcceptExRemoteLength
+
+template acceptCommon(listener: SocketFD, conn: var Handle[SocketFD],
+                      remote: var IP4EndpointImpl, overlapped: static bool) =
+  # Common parts for dealing with AcceptEx, `overlapped` dictates whether the
+  # operation should be done in an overlapped manner and yields an overlapped
+  # socket.
+  conn = initHandle:
+    SocketFD:
+      WSASocketW(AF_INET, SOCK_STREAM, IPPROTO_TCP, nil, 0):
+        toWSAFlags:
+          when overlapped:
+            {sfOverlapped}
+          else:
+            {}
+
+  if conn.get == InvalidFD:
+    raise newOSError(WSAGetLastError(), $Error.Accept)
+
+  var
+    buf: array[AcceptExBufferLength, byte]
+    # unused since the receive function is not used but is required
+    received: DWORD
+    overlapObj = new Overlapped
+
+  when overlapped:
+    # Register the listener to IOCP so asynchronous operations can be done.
+    persist(listener)
+
+  if AcceptEx(
+    wincore.Socket(listener),
+    wincore.Socket(conn.get),
+    addr buf[0],
+    0,
+    AcceptExLocalLength,
+    AcceptExRemoteLength,
+    addr received,
+    cast[ptr Overlapped](addr overlapObj[])
+  ) == wincore.False:
+    var errorCode = WSAGetLastError()
+
+    when overlapped:
+      # If the operation is being done asynchronously
+      if errorCode == WSAIoPending:
+        # Wait for its completion
+        wait(listener, overlapObj)
+
+        var flags: DWORD # unused but required
+        # Get the operation result
+        if WSAGetOverlappedResult(
+          wincore.Socket(listener),
+          cast[ptr Overlapped](addr overlapObj[]),
+          addr received,
+          fWait = wincore.False,
+          addr flags
+        ) == wincore.False:
+          errorCode = WSAGetLastError()
+        else:
+          errorCode = ErrorSuccess
+
+    else:
+      assert errorCode != WSAIoPending:
+        "AcceptEx yields IO_PENDING for non-overlapped socket, this is a nim-sys bug"
+
+    if errorCode != ErrorSuccess:
+      raise newOSError(errorCode, $Error.Accept)
+
+  var
+    # We don't use the "local" part but the "remote" part is used
+    localAddrLength, remoteAddrLength: cint
+    # Slices of the buffer for local and remote addresses
+    localAddr, remoteAddr: ptr Sockaddr
+
+  GetAcceptExSockaddrs(
+    addr buf[0],
+    0, AcceptExLocalLength, AcceptExRemoteLength,
+    addr localAddr, addr localAddrLength,
+    addr remoteAddr, addr remoteAddrLength
+  )
+
+  # TODO: Remove this once IPv6 support lands
+  #
+  # This is used to verify that we are getting IPv4 address.
+  assert remoteAddrLength == sizeof remote:
+    "The length of the endpoint structure does not match assumption. This is a nim-sys bug."
+  assert remoteAddr.sa_family == AF_INET:
+    "The address is not IPv4. This is a nim-sys bug."
+
+  # Copy the remote address
+  remote = cast[ptr IP4EndpointImpl](remoteAddr)[]
+
+  # Update the connection attributes so that other functions can be used on the
+  # socket.
+  var listenerSock = listener
+  if setsockopt(
+    wincore.Socket(conn.get),
+    SolSocket,
+    SoUpdateAcceptContext,
+    cast[cstring](addr listenerSock),
+    cint sizeof(listenerSock)
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.Accept)
+
+template tcpAccept() {.dirty.} =
+  var conn = initHandle(SocketFD InvalidFD)
+  acceptCommon(l.fd, conn, result.remote, overlapped = false)
+  result.conn = Conn[TCP] newSocket(conn)
+
+template tcpAsyncAccept() {.dirty.} =
+  var conn = initHandle(SocketFD InvalidFD)
+  acceptCommon(l.fd, conn, result.remote, overlapped = true)
+  result.conn = AsyncConn[TCP] newAsyncSocket(move conn)
+
+template tcpLocalEndpoint() {.dirty.} =
+  var endpointLen = cint sizeof(result)
+
+  if getsockname(
+    wincore.Socket(l.fd),
+    cast[ptr sockaddr](addr result),
+    addr endpointLen
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), $Error.LocalEndpoint)
+
+  assert endpointLen == sizeof(result):
+    "The length of the endpoint structure does not match assumption. This is a nim-sys bug."
+  assert result.sin_family == AF_INET:
+    "The address is not IPv4. This is a nim-sys bug."
+
+proc initWinsock() =
+  ## Initializes winsock for use with sys/sockets
+  var data: WSAData
+  # Request Windows Sockets version 2.2, which is the latest at the time of
+  # writing.
+  let errorCode = WSAStartup(MakeWord(2, 2), addr data)
+
+  if errorCode != 0:
+    raise newOSError(errorCode, "Unable to initialize Windows Sockets")
+
+  # If the version is older than winsock 2.2 (note: DLLs supporting newer
+  # version will still report 2.2 since that's what was requested)
+  if data.wVersion != MakeWord(2, 2):
+    # Cleanup then raise
+    WSACleanup()
+    raise newException(CatchableError, "Unable to find an usable Windows Sockets version")
+
+  # Create a dummy socket so we can obtain necessary functions
+  let dummy = initHandle:
+    SocketFD:
+      WSASocketW(AF_INET, SOCK_STREAM, 0, nil, 0, toWSAFlags({}))
+
+  if dummy.get == InvalidFD:
+    raise newOSError(WSAGetLastError(), "Could not initialize sys/sockets")
+
+  # Obtain the function pointer for ConnectEx
+  var
+    fnGuid = WSAID_CONNECTEX
+    bytesReturned: DWORD
+  if WSAIoctl(
+    wincore.Socket(dummy.get),
+    SIO_GET_EXTENSION_FUNCTION_POINTER,
+    addr fnGuid,
+    DWORD sizeof(fnGuid),
+    addr ConnectEx,
+    DWORD sizeof(ConnectEx),
+    addr bytesReturned,
+    nil,
+    nil
+  ) == SocketError:
+    raise newOSError(WSAGetLastError(), "Could not get pointer to ConnectEx")
+
+  assert bytesReturned == sizeof(ConnectEx):
+    "Wrong size returned for function pointer. This is a nim-sys bug."
+
+# Initialize winsock on program startup.
+initWinsock()

--- a/src/sys/private/syscall/posix.nim
+++ b/src/sys/private/syscall/posix.nim
@@ -37,7 +37,7 @@ template retryOnEIntr*(op: untyped): untyped =
   while true:
     result = op
 
-    if result == -1 and errno == EINTR:
+    if cint(result) == -1 and errno == EINTR:
       discard "Got interrupted, try again"
     else:
       break

--- a/src/sys/private/syscall/posix.nim
+++ b/src/sys/private/syscall/posix.nim
@@ -24,6 +24,8 @@ when defined(bsd) or defined(linux) or defined(macosx):
   let FIONCLEX* {.importc, header: "<sys/ioctl.h>".}: culong
 
 when defined(bsd) or defined(linux):
+  let SOCK_NONBLOCK* {.importc, header: "<sys/socket.h>".}: cint
+
   proc dup3*(oldfd, newfd, flags: cint): cint {.importc, header: "<unistd.h>".}
   proc pipe2*(pipefd: var array[2, cint],
               flags: cint): cint {.importc, header: "<unistd.h>".}

--- a/src/sys/sockets.nim
+++ b/src/sys/sockets.nim
@@ -86,17 +86,17 @@ proc close*(s: AsyncSocket) {.inline.} =
 
 # These are used to ensure correct destructor binding
 {.warning: "compiler bug workaround; see: https://github.com/nim-lang/Nim/issues/19138".}
-func newSocketAs(T: typedesc[not ref], fd: SocketFD): ref T {.inline.} =
+proc newSocketAs(T: typedesc[not ref], fd: SocketFD): ref T {.inline.} =
   ## Create a ref socket from `fd`, converted to `T`.
   new result
   result[] = T SocketObj(handle: initHandle(fd))
 
-func newSocketAs(T: typedesc[not ref], handle: sink Handle[SocketFD]): ref T {.inline.} =
+proc newSocketAs(T: typedesc[not ref], handle: sink Handle[SocketFD]): ref T {.inline.} =
   ## Create a ref socket from `handle`, converted to `T`.
   new result
   result[] = T SocketObj(handle: handle)
 
-func newSocket*(fd: SocketFD): Socket {.inline.} =
+proc newSocket*(fd: SocketFD): Socket {.inline.} =
   ## Creates a new `Socket` from an opened socket handle.
   ##
   ## The ownership of the handle will be transferred to the resulting `Socket`.
@@ -111,7 +111,7 @@ func newSocket*(fd: SocketFD): Socket {.inline.} =
   ##   <#newAsyncSocket.SocketFD>` instead.
   newSocketAs(SocketObj, fd)
 
-func newAsyncSocket*(fd: SocketFD): AsyncSocket {.inline.} =
+proc newAsyncSocket*(fd: SocketFD): AsyncSocket {.inline.} =
   ## Creates a new `AsyncSocket` from an opened socket handle.
   ##
   ## The ownership of the handle will be transferred to the resulting `Socket`.
@@ -126,7 +126,7 @@ func newAsyncSocket*(fd: SocketFD): AsyncSocket {.inline.} =
   ## - On Windows, it is assumed that `fd` is opened in overlapped mode.
   newSocketAs(AsyncSocketObj, fd)
 
-func newSocket*(handle: sink Handle[SocketFD]): Socket {.inline.} =
+proc newSocket*(handle: sink Handle[SocketFD]): Socket {.inline.} =
   ## Creates a new `Socket` from an opened socket handle.
   ##
   ## The ownership of the handle will be transferred to the resulting `Socket`.
@@ -141,7 +141,7 @@ func newSocket*(handle: sink Handle[SocketFD]): Socket {.inline.} =
   ##   <#newAsyncSocket.SocketFD>` instead.
   newSocketAs(SocketObj, handle)
 
-func newAsyncSocket*(handle: sink Handle[SocketFD]): AsyncSocket {.inline.} =
+proc newAsyncSocket*(handle: sink Handle[SocketFD]): AsyncSocket {.inline.} =
   ## Creates a new `AsyncSocket` from an opened socket handle.
   ##
   ## The ownership of the handle will be transferred to the resulting `Socket`.

--- a/src/sys/sockets.nim
+++ b/src/sys/sockets.nim
@@ -86,7 +86,7 @@ proc close*(s: AsyncSocket) {.inline.} =
   ## The FD associated with `s` will be deregistered from `ioqueue`.
   close s[]
 
-func newSocket*(fd: SocketFD): Socket =
+func newSocket*(fd: SocketFD): Socket {.inline.} =
   ## Creates a new `Socket` from an opened socket handle.
   ##
   ## The ownership of the handle will be transferred to the resulting `Socket`.
@@ -101,7 +101,7 @@ func newSocket*(fd: SocketFD): Socket =
   ##   <#newAsyncSocket.SocketFD>` instead.
   Socket(handle: initHandle(fd))
 
-func newAsyncSocket*(fd: SocketFD): AsyncSocket =
+func newAsyncSocket*(fd: SocketFD): AsyncSocket {.inline.} =
   ## Creates a new `AsyncSocket` from an opened socket handle.
   ##
   ## The ownership of the handle will be transferred to the resulting `Socket`.
@@ -115,6 +115,36 @@ func newAsyncSocket*(fd: SocketFD): AsyncSocket =
   ##
   ## - On Windows, it is assumed that `fd` is opened in overlapped mode.
   AsyncSocket newSocket(fd)
+
+func newSocket*(handle: sink Handle[SocketFD]): Socket {.inline.} =
+  ## Creates a new `Socket` from an opened socket handle.
+  ##
+  ## The ownership of the handle will be transferred to the resulting `Socket`.
+  ##
+  ## **Note**: It is assumed that the handle has been opened in synchronous
+  ## mode. Only use this interface if you know what you are doing.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On Windows, sockets created via Winsock `socket()` function are opened
+  ##   in overlapped mode and should be passed to `newAsyncSocket
+  ##   <#newAsyncSocket.SocketFD>` instead.
+  Socket(handle: handle)
+
+func newAsyncSocket*(handle: sink Handle[SocketFD]): AsyncSocket {.inline.} =
+  ## Creates a new `AsyncSocket` from an opened socket handle.
+  ##
+  ## The ownership of the handle will be transferred to the resulting `Socket`.
+  ##
+  ## **Note**: It is assumed that the handle has been opened in asynchronous
+  ## mode. Only use this interface if you know what you are doing.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On POSIX, it is assumed that `fd` is opened with `O_NONBLOCK` set.
+  ##
+  ## - On Windows, it is assumed that `fd` is opened in overlapped mode.
+  AsyncSocket newSocket(handle)
 
 template derive(T, Base: typedesc): untyped =
   ## Template to mass-borrow socket operations.

--- a/src/sys/sockets.nim
+++ b/src/sys/sockets.nim
@@ -182,26 +182,8 @@ type
 
 when defined(posix):
   include private/sockets_posix
-elif defined(nimdoc):
-  # Provide dummies implementation template for nimdoc
-  template readImpl() = discard
-  template asyncReadImpl() = discard
-  template writeImpl() = discard
-  template asyncWriteImpl() = discard
-  template ip4Word() = discard
-  template ip4SetWord() = discard
-  template ip4InitEndpoint() = discard
-  template ip4EndpointAddr() = discard
-  template ip4EndpointPort() = discard
-  template ip4Resolve() = discard
-  template resolvedItems() = discard
-  template tcpConnect() = discard
-  template tcpAsyncConnect() = discard
-  template tcpListen() = discard
-  template tcpAsyncListen() = discard
-  template tcpAccept() = discard
-  template tcpAsyncAccept() = discard
-  template tcpLocalEndpoint() = discard
+elif defined(windows):
+  include private/sockets_windows
 else:
   {.error: "This module has not been ported to your operating system.".}
 

--- a/src/sys/sockets.nim
+++ b/src/sys/sockets.nim
@@ -1,0 +1,722 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+## Abstractions for networking operations over sockets.
+
+{.experimental: "implicitDeref".}
+
+import system except IOError
+
+import std/[genasts, macros]
+import pkg/stew/endians2
+import files, handles, ioqueue
+
+type
+  SocketObj = object
+    ## An object representing a socket. This is meant to be used as a base to
+    ## specialize into other sockets type. Direct usage of this socket type is
+    ## discouraged.
+    handle: Handle[SocketFD]
+
+  Socket = ref SocketObj
+    ## A generic `Socket`.
+
+  AsyncSocketObj {.borrow: `.`.} = distinct SocketObj
+    ## A `SocketObj` opened in asynchronous mode.
+
+  AsyncSocket = ref AsyncSocketObj
+    ## A `Socket` opened in asynchronous mode.
+
+  AnySocket = AsyncSocket | Socket
+    ## A typeclass for the two basic socket types
+
+proc `=copy`(dest: var SocketObj, src: SocketObj) {.error.}
+
+func fd*(s: AnySocket): SocketFD {.inline.} =
+  ## Returns the handle held by `s`.
+  ##
+  ## The returned `SocketFD` will stay valid for the duration of `s`.
+  get s.handle
+
+func takeFD*(s: AnySocket): SocketFD {.inline.} =
+  ## Returns the file handle held by `s` and release ownership to the caller.
+  ## `s` will be invalidated.
+  ##
+  ## If `s` is asynchronous, it will *not* be unregistered from the queue.
+  take s.handle
+
+proc close(s: var SocketObj) {.inline.} =
+  ## Closes and invalidates the socket `s`.
+  ##
+  ## If `s` is invalid, `ClosedHandleDefect` will be raised.
+  close s.handle
+
+proc close(s: var AsyncSocketObj) {.inline.}
+
+proc `=destroy`(s: var AsyncSocketObj) =
+  ## Destroy the asynchronous socket `s`.
+  if s.handle.get != InvalidFD:
+    close(s)
+
+proc close(s: var AsyncSocketObj) {.inline.} =
+  ## Closes and invalidates the socket `s`.
+  ##
+  ## If `s` is invalid, `ClosedHandleDefect` will be raised.
+  ##
+  ## The FD associated with `s` will be deregistered from `ioqueue`.
+  unregister s.handle.get
+  close SocketObj(s)
+
+proc close*(s: Socket) {.inline.} =
+  ## Closes and invalidates the socket `s`.
+  ##
+  ## If `s` is invalid, `ClosedHandleDefect` will be raised.
+  close s[]
+
+proc close*(s: AsyncSocket) {.inline.} =
+  ## Closes and invalidates the socket `s`.
+  ##
+  ## If `s` is invalid, `ClosedHandleDefect` will be raised.
+  ##
+  ## The FD associated with `s` will be deregistered from `ioqueue`.
+  close s[]
+
+func newSocket*(fd: SocketFD): Socket =
+  ## Creates a new `Socket` from an opened socket handle.
+  ##
+  ## The ownership of the handle will be transferred to the resulting `Socket`.
+  ##
+  ## **Note**: It is assumed that the handle has been opened in synchronous
+  ## mode. Only use this interface if you know what you are doing.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On Windows, sockets created via Winsock `socket()` function are opened
+  ##   in overlapped mode and should be passed to `newAsyncSocket
+  ##   <#newAsyncSocket.SocketFD>` instead.
+  Socket(handle: initHandle(fd))
+
+func newAsyncSocket*(fd: SocketFD): AsyncSocket =
+  ## Creates a new `AsyncSocket` from an opened socket handle.
+  ##
+  ## The ownership of the handle will be transferred to the resulting `Socket`.
+  ##
+  ## **Note**: It is assumed that the handle has been opened in asynchronous
+  ## mode. Only use this interface if you know what you are doing.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On POSIX, it is assumed that `fd` is opened with `O_NONBLOCK` set.
+  ##
+  ## - On Windows, it is assumed that `fd` is opened in overlapped mode.
+  AsyncSocket newSocket(fd)
+
+template derive(T, Base: typedesc): untyped =
+  ## Template to mass-borrow socket operations.
+  template fd*(s: T): SocketFD =
+    Base(s).fd
+  template takeFD*(s: T): SocketFD =
+    takeFD Base(s)
+  template close*(s: T) =
+    close Base(s)
+
+type
+  Protocol* {.pure.} = enum
+    TCP
+
+  Conn*[Protocol: static Protocol] = distinct Socket
+    ## A connection with `Protocol`.
+
+  AsyncConn*[Protocol: static Protocol] = distinct AsyncSocket
+    ## An asynchronous connection with `Protocol`.
+
+derive Conn, Socket
+derive AsyncConn, AsyncSocket
+
+type
+  Error {.pure.} = enum
+    ## Enum containing error messages for use by this module
+    InvalidFamily = "This address family is not supported by the operating system"
+    Read = "Could not read from socket"
+    Write = "Could not write into socket"
+    Resolve = "Could not resolve the given host"
+    Connect = "A connection could not be made to the endpoint"
+    Listen = "Could not create a listener at the endpoint"
+    Accept = "Could not accept any connection from the listener"
+    LocalEndpoint = "Could not obtain the local endpoint"
+
+when defined(posix):
+  include private/sockets_posix
+elif defined(nimdoc):
+  # Provide dummies implementation template for nimdoc
+  template readImpl() = discard
+  template asyncReadImpl() = discard
+  template writeImpl() = discard
+  template asyncWriteImpl() = discard
+  template ip4Word() = discard
+  template ip4SetWord() = discard
+  template ip4InitEndpoint() = discard
+  template ip4EndpointAddr() = discard
+  template ip4EndpointPort() = discard
+  template ip4Resolve() = discard
+  template resolvedItems() = discard
+  template tcpConnect() = discard
+  template tcpAsyncConnect() = discard
+  template tcpListen() = discard
+  template tcpAsyncListen() = discard
+  template tcpAccept() = discard
+  template tcpAsyncAccept() = discard
+  template tcpLocalEndpoint() = discard
+else:
+  {.error: "This module has not been ported to your operating system.".}
+
+proc read*[T: byte or char](s: Conn, b: var openArray[T]): int =
+  ## Reads up to `b.len` bytes from socket `s` into `b`.
+  ##
+  ## If the other endpoint is closed, no data will be read and no error will be
+  ## raised.
+  ##
+  ## Returns the number of bytes read from `s`.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On POSIX systems, signals will not interrupt the operation if nothing
+  ##   was read.
+  readImpl()
+
+proc write*[T: byte or char](s: Conn, b: openArray[T]): int =
+  ## Writes the contents of array `b` into socket `s`.
+  ##
+  ## Returns the number of bytes written to `s`.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On POSIX systems, signals will not interrupt the operation if nothing
+  ##   was written.
+  writeImpl()
+
+macro implGenericAsyncConn(): untyped =
+  ## Implement async operations on the generic type `AsyncConn` by manually
+  ## specializing the operations for each `Protocol`.
+  ##
+  ## TODO: Get CPS generics working and deal with this mess...
+  result = newStmtList()
+
+  for proto in Protocol.items:
+    result.add:
+      genAstOpt({kDirtyTemplate}, proto = newLit(proto)):
+        proc read*(s: AsyncConn[proto], buf: ptr UncheckedArray[byte],
+                   bufLen: Natural): int {.asyncio.} =
+          ## Reads up to `bufLen` bytes from socket `s` into `buf`.
+          ##
+          ## `buf` must stays alive for the duration of the operation. Direct usage
+          ## of this interface is discouraged due to its unsafetyness. Users are
+          ## encouraged to use the high-level overloads that keep buffers alive.
+          ##
+          ## If the other endpoint is closed, no data will be read and no error
+          ## will be raised.
+          ##
+          ## Returns the number of bytes read from `s`.
+          ##
+          ## **Platform specific details**
+          ##
+          ## - On POSIX systems, signals will not interrupt the operation.
+          if buf == nil and bufLen != 0:
+            raise newException(ValueError, "A buffer must be provided for request of size > 0")
+
+          asyncReadImpl()
+
+        proc read*(s: AsyncConn[proto], b: ref string): int {.asyncio.} =
+          ## Reads up to `b.len` bytes from socket `s` into `b`.
+          ##
+          ## This is an overload of read(s, buf, bufLen), plese refer to its
+          ## documentation for more information.
+          if b.len > 0:
+            read(s, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+          else:
+            read(s, nil, 0)
+
+        proc read*(s: AsyncConn[proto], b: ref seq[byte]): int {.asyncio.} =
+          ## Reads up to `b.len` bytes from socket `s` into `b`.
+          ##
+          ## This is an overload of read(s, buf, bufLen), plese refer to its
+          ## documentation for more information.
+          if b.len > 0:
+            read(s, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+          else:
+            read(s, nil, 0)
+
+        proc write*(s: AsyncConn[proto], buf: ptr UncheckedArray[byte],
+                    bufLen: Natural): int {.asyncio.} =
+          ## Writes up to `bufLen` bytes from `buf` to socket `s`.
+          ##
+          ## `buf` must stays alive for the duration of the operation. Direct usage
+          ## of this interface is discouraged due to its unsafetyness. Users are
+          ## encouraged to use the high-level overloads that keep the buffer alive.
+          ##
+          ## Returns the number of bytes written into `s`.
+          ##
+          ## **Platform specific details**
+          ##
+          ## - On POSIX systems, signals will not interrupt the operation.
+          if buf == nil and bufLen != 0:
+            raise newException(ValueError, "A buffer must be provided for request of size > 0")
+
+          asyncWriteImpl()
+
+        proc write*(s: AsyncConn[proto], b: string): int {.asyncio.} =
+          ## Writes up to `b.len` bytes from `b` to socket `s`. The contents of
+          ## `b` will be copied prior to the operation. Consider the `ref`
+          ## overload to avoid copies.
+          ##
+          ## This is an overload of write(s, buf, bufLen), plese refer to its
+          ## documentation for more information.
+          if b.len > 0:
+            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[0]), b.len)
+          else:
+            write(s, nil, 0)
+
+        proc write*(s: AsyncConn[proto], b: seq[byte]): int {.asyncio.} =
+          ## Writes up to `b.len` bytes from `b` to socket `s`. The contents of
+          ## `b` will be copied prior to the operation. Consider the `ref`
+          ## overload to avoid copies.
+          ##
+          ## This is an overload of write(s, buf, bufLen), plese refer to its
+          ## documentation for more information.
+          if b.len > 0:
+            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[0]), b.len)
+          else:
+            write(s, nil, 0)
+
+        proc write*(s: AsyncConn[proto], b: ref string): int {.asyncio.} =
+          ## Writes up to `b.len` bytes from `b` to socket `s`.
+          ##
+          ## This is an overload of write(s, buf, bufLen), plese refer to its
+          ## documentation for more information.
+          if b.len > 0:
+            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[0]), b.len)
+          else:
+            write(s, nil, 0)
+
+        proc write*(s: AsyncConn[proto], b: ref seq[byte]): int {.asyncio.} =
+          ## Writes up to `b.len` bytes from `b` into socket `s`.
+          ##
+          ## This is an overload of write(s, buf, bufLen), plese refer to its
+          ## documentation for more information.
+          if b.len > 0:
+            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[0]), b.len)
+          else:
+            write(s, nil, 0)
+
+implGenericAsyncConn()
+
+type
+  IP4* = IP4Impl
+    ## An IPv4 address.
+
+func word(ip: IP4): uint32 {.inline.} =
+  ## Obtain the address from `ip` as an integer in big endian.
+  ip4Word()
+
+func `word=`(ip: var IP4, w: uint32) {.inline.} =
+  ## Set the address referenced to by `ip` to `w`, with `w` in big endian.
+  ip4SetWord()
+
+func ip4*(a, b, c, d: byte): IP4 {.inline.} =
+  ## Returns the `IP4` object of the IP address `a.b.c.d`.
+  result.word = fromBytesBE(uint32, [a, b, c, d]).toBE()
+
+const
+  IP4Loopback* = ip4(127, 0, 0, 1)
+    ## The IPv4 loopback address.
+
+  IP4Any* = ip4(0, 0, 0, 0)
+    ## The IPv4 address used to signify binding to any address.
+
+  IP4Broadcast* = ip4(255, 255, 255, 255)
+    ## The IPv4 address used to signify any host.
+
+func `==`*(a, b: IP4): bool {.inline.} =
+  ## Returns whether `a` and `b` points to the same address.
+  a.word == b.word
+
+func `[]`*(ip: IP4, idx: Natural): byte {.inline.} =
+  ## Returns octet at position `idx` of `ip`.
+  runnableExamples:
+    let ip = ip4(127, 0, 0, 1)
+    doAssert ip[0] == 127
+
+  ip.word.fromBE().toBytesBE()[idx]
+
+func `[]=`*(ip: var IP4, idx: Natural, val: byte) {.inline.} =
+  ## Set the octet at position `idx` to `val`.
+  runnableExamples:
+    var ip = ip4(127, 0, 0, 1)
+    ip[0] = 10
+    doAssert ip == ip4(10, 0, 0, 1)
+
+  var address = ip.word.fromBE().toBytesBE()
+  address[idx] = val
+  ip.word = fromBytesBE(uint32, address).toBE()
+
+func len*(ip: IP4): int {.inline.} =
+  ## Returns the number of octets in `ip`.
+  4
+
+func `$`*(ip: IP4): string {.inline.} =
+  ## Returns the string representation of `ip`.
+  result = $ip[0] & '.' & $ip[1] & '.' & $ip[2] & '.' & $ip[3]
+
+type
+  Port* = distinct uint16
+    ## The port number type.
+
+  IP4Endpoint* = IP4EndpointImpl
+    ## An IPv4 endpoint, which is a combination of an IPv4 address and a port.
+
+const
+  PortNone* = 0.Port
+    ## The port that means "no port". Different procedures will interpret this
+    ## value differently.
+
+func `$`*(p: Port): string {.borrow.}
+func `==`*(a, b: Port): bool {.borrow.}
+
+proc initEndpoint*(ip: IP4, port: Port): IP4Endpoint =
+  ## Creates an endpoint from an IP address and a port.
+  ip4InitEndpoint()
+
+proc ip*(e: IP4Endpoint): IP4 =
+  ## Returns the IPv4 address of the endpoint.
+  ip4EndpointAddr()
+
+proc port*(e: IP4Endpoint): Port =
+  ## Returns the port of the endpoint.
+  ip4EndpointPort()
+
+type
+  ResolverResult* = ref ResolverResultImpl
+    ## The result of a `resolve()` operation
+
+  ResolverError* = object of CatchableError
+    ## The exception type for errors during resolving that is not caused by the OS.
+    # TODO: add a way to interpret the error code.
+    errorCode*: int32 ## The error code as returned by the resolver. This value is platform-dependant.
+
+proc `=copy`*(dst: var ResolverResultImpl, src: ResolverResultImpl) {.error.}
+  ## Copying a `ResolverResult` is prohibited at the moment. This restriction
+  ## might be lifted in the future.
+
+proc resolveIP4*(host: string, port: Port = PortNone): ResolverResult
+                {.raises: [OSError, ResolverError].} =
+  ## Resolve the endpoints of `host` for port `port`.
+  ##
+  ## `port` will be carried over to the result verbatim.
+  ##
+  ## On failure, either `OSError` or `ResolverError` will be raised, depending
+  ## on whether the error was caused by the operating system or the resolver.
+  ##
+  ## **Platform specific details**
+  ##
+  ## - On POSIX, the error code in `ResolverError` will be the error returned via `getaddrinfo()` function.
+  ##
+  ## - On Windows, the error code in `ResolverError` is one of the errors in this
+  ##   `list <https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfow#return-value>`_.
+  ##   Other errors are reported as `OSError`.
+  ip4Resolve()
+
+# In the future this should be either generic or use `Endpoint`.
+iterator items*(r: ResolverResult): IP4Endpoint =
+  ## Yields endpoints from the resolving result
+  resolvedItems()
+
+func closureItems(r: ResolverResult): iterator (): IP4Endpoint =
+  ## Produce a closure iterator for `r.items`. This is necessary for use in CPS.
+  result =
+    iterator(): IP4Endpoint =
+      for ep in r.items:
+        yield ep
+
+type
+  IncompatibleEndpointError* = object of CatchableError
+    ## Raised when connect or listen is used with `ResolverResult` but there
+    ## are no compatible endpoint found.
+
+func newIncompatibleEndpointError*(): ref IncompatibleEndpointError {.inline.} =
+  ## Create an instance of `IncompatibleAddressError`.
+  newException(IncompatibleEndpointError, "There are no compatible endpoint in the given list")
+
+proc connectTcp*(endpoint: IP4Endpoint): Conn[TCP]
+                {.raises: [OSError].} =
+  ## Create a TCP connection to `endpoint`.
+  tcpConnect()
+
+proc connectTcp*(endpoints: ResolverResult): Conn[TCP]
+                {.raises: [OSError, IncompatibleEndpointError].} =
+  ## Connects via TCP to one of the compatible endpoint from `endpoints`.
+  ##
+  ## The first endpoint to connect successfully will be used.
+  ##
+  ## If there are no compatible addresses in `endpoints`,
+  ## `IncompatibleEndpointError` will be raised.
+  ##
+  ## If connection fails for all `endpoints`, the `OSError` raised will be of
+  ## the last endpoint tried.
+  var
+    attempted = false
+    lastError: ref OSError
+  for ep in endpoints.items:
+    attempted = true
+    try:
+      result = connectTcp(ep)
+    except OSError as e:
+      lastError = e
+      continue
+
+    # If there are no errors, then we can just return here
+    return
+
+  # This should only be reached if either connection failed or it wasn't attempted.
+  if not attempted:
+    raise newIncompatibleEndpointError()
+  else:
+    raise lastError
+
+proc connectTcp*(host: IP4, port: Port): Conn[TCP]
+                {.inline, raises: [OSError].} =
+  ## Create a TCP connection to `host` and `port`.
+  connectTcp initEndpoint(host, port)
+
+proc connectTcp*(host: string, port: Port): Conn[TCP]
+                {.inline, raises: [OSError, ResolverError, IncompatibleEndpointError].} =
+  ## Create a TCP connection to `host` and `port`.
+  ##
+  ## `host` will be resolved before connection.
+  connectTcp resolveIP4(host, port)
+
+proc connectTcpAsync*(endpoint: IP4Endpoint): AsyncConn[TCP]
+                     {.asyncio.} =
+  ## Create an asynchronous TCP connection to `endpoint`.
+  ##
+  ## `OSError` is raised if the connection fails.
+  tcpAsyncConnect()
+
+proc connectTcpAsync*(endpoints: ResolverResult): AsyncConn[TCP]
+                     {.asyncio.} =
+  ## Connects via TCP to one of the compatible endpoint from `endpoints`.
+  ##
+  ## The first endpoint to connect successfully will be used.
+  ##
+  ## If there are no compatible addresses in `endpoints`,
+  ## `IncompatibleEndpointError` will be raised.
+  ##
+  ## If connection fails for all `endpoints`, the `OSError` raised will be of
+  ## the last endpoint tried.
+  ##
+  ## **Note**: It might be necessary to perform an explicit `move` into this
+  ## parameter.
+  var
+    attempted = false
+    lastError: ref OSError
+  {.warning: "Workaround for nim-works/cps#185".}
+  let next: iterator (): IP4Endpoint = closureItems(endpoints)
+  while true:
+    attempted = true
+    let ep = next()
+    # The finished state is evaluated after the call.
+    if next.finished: break
+
+    try:
+      result = connectTcpAsync(ep)
+    except OSError as e:
+      lastError = e
+      continue
+
+    # If there are no errors, then we can just return here
+    return
+
+  # This should only be reached if either connection failed or it wasn't attempted.
+  if not attempted:
+    raise newIncompatibleEndpointError()
+  else:
+    raise lastError
+
+proc connectTcpAsync*(host: IP4, port: Port): AsyncConn[TCP]
+                     {.asyncio.} =
+  ## Create a TCP connection to `host` and `port`.
+  connectTcpAsync initEndpoint(host, port)
+
+proc connectTcpAsync*(host: string, port: Port): AsyncConn[TCP]
+                     {.asyncio.} =
+  ## Create a TCP connection to `host` and `port`.
+  ##
+  ## `host` will be resolved **synchronously** before connection.
+  # A move have to be done or the compiler might think that this is a copy.
+  var resolverResult = resolveIP4(host, port)
+  connectTcpAsync move(resolverResult)
+
+type
+  Listener*[Protocol: static Protocol] = distinct Socket
+    ## A listener with `Protocol`.
+
+  AsyncListener*[Protocol: static Protocol] = distinct AsyncSocket
+    ## An asynchronous listener with `Protocol`.
+
+derive Listener, Socket
+derive AsyncListener, AsyncSocket
+
+proc listenTcp*(endpoint: IP4Endpoint): Listener[TCP]
+               {.raises: [OSError].} =
+  ## Listen at `endpoint` for TCP connections.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to retrieve the port number.
+  tcpListen()
+
+proc listenTcp*(endpoints: ResolverResult): Listener[TCP]
+                {.raises: [OSError, IncompatibleEndpointError].} =
+  ## Listen for TCP connections at one of the endpoint in `endpoints`.
+  ##
+  ## The first endpoint listened to successfully will be used.
+  ##
+  ## If there are no compatible addresses in `endpoints`,
+  ## `IncompatibleEndpointError` will be raised.
+  ##
+  ## If listening fails for all `endpoints`, the `OSError` raised will be of
+  ## the last endpoint tried.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to retrieve the port number.
+  var
+    attempted = false
+    lastError: ref OSError
+  for ep in endpoints.items:
+    attempted = true
+    try:
+      result = listenTcp(ep)
+    except OSError as e:
+      lastError = e
+      continue
+
+    # If there are no errors, then we can just return here
+    return
+
+  # This should only be reached if either listening failed or it wasn't attempted.
+  if not attempted:
+    raise newIncompatibleEndpointError()
+  else:
+    raise lastError
+
+proc listenTcp*(host: IP4, port: Port): Listener[TCP]
+               {.inline, raises: [OSError].} =
+  ## Listen at `host` and `port` for TCP connections.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to fetch this data.
+  listenTcp initEndpoint(host, port)
+
+proc listenTcp*(host: string, port: Port): Listener[TCP]
+               {.inline, raises: [OSError, IncompatibleEndpointError, ResolverError].} =
+  ## Listen at `host` and `port` for TCP connections.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to retrieve the port number.
+  listenTcp resolveIP4(host, port)
+
+proc listenTcpAsync*(endpoint: IP4Endpoint): AsyncListener[TCP]
+                    {.asyncio.} =
+  ## Listen at `endpoint` for TCP connections asynchronously.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to retrieve the port number.
+  tcpAsyncListen()
+
+proc listenTcpAsync*(endpoints: ResolverResult): AsyncListener[TCP]
+                    {.asyncio.} =
+  ## Listen for TCP connections at one of the endpoint in `endpoints`.
+  ##
+  ## The first endpoint listened to successfully will be used.
+  ##
+  ## If there are no compatible addresses in `endpoints`,
+  ## `IncompatibleEndpointError` will be raised.
+  ##
+  ## If listening fails for all `endpoints`, the `OSError` raised will be of
+  ## the last endpoint tried.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to retrieve the port number.
+  ##
+  ## **Note**: It might be necessary to perform an explicit `move` into this
+  ## parameter.
+  var
+    attempted = false
+    lastError: ref OSError
+  {.warning: "Workaround for nim-works/cps#185".}
+  let next: iterator (): IP4Endpoint = closureItems(endpoints)
+  while true:
+    attempted = true
+    let ep = next()
+    # The finished state is evaluated after the call.
+    if next.finished: break
+
+    try:
+      result = listenTcpAsync(ep)
+    except OSError as e:
+      lastError = e
+      continue
+
+    # If there are no errors, then we can just return here
+    return
+
+  # This should only be reached if either listening failed or it wasn't attempted.
+  if not attempted:
+    raise newIncompatibleEndpointError()
+  else:
+    raise lastError
+
+proc listenTcpAsync*(host: IP4, port: Port): AsyncListener[TCP]
+                    {.asyncio.} =
+  ## Listen at `host` and `port` for TCP connections.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to retrieve the port number.
+  listenTcpAsync initEndpoint(host, port)
+
+proc listenTcpAsync*(host: string, port: Port): AsyncListener[TCP]
+                    {.asyncio.} =
+  ## Listen at `host` and `port` for TCP connections.
+  ##
+  ## If the port of the endpoint is `PortNone`, an ephemeral port will be
+  ## reserved automatically by the operating system. `localEndpoint` can be
+  ## used to retrieve the port number.
+  # A move have to be performed due to the compiler thinking that this is a
+  # "copy".
+  listenTcpAsync resolveIP4(host, port)
+
+proc accept*(l: Listener[TCP]): tuple[conn: Conn[TCP], remote: IP4Endpoint] {.raises: [OSError].} =
+  ## Get the first connection from the queue of pending connections of `l`.
+  ##
+  ## Returns the connection and its endpoint.
+  tcpAccept()
+
+proc accept*(l: AsyncListener[TCP]): tuple[conn: AsyncConn[TCP], remote: IP4Endpoint] {.asyncio.} =
+  ## Get the first connection from the queue of pending connections of `l`.
+  ##
+  ## Returns the connection and its endpoint.
+  tcpAsyncAccept()
+
+proc localEndpoint*(l: AsyncListener[TCP] | Listener[TCP]): IP4Endpoint {.raises: [OSError].} =
+  ## Obtain the local endpoint of `l`.
+  tcpLocalEndpoint()

--- a/src/sys/sockets.nim
+++ b/src/sys/sockets.nim
@@ -11,8 +11,9 @@
 import system except IOError
 
 import std/[genasts, macros, options]
-import pkg/stew/endians2
 import files, handles, ioqueue
+import sockets/addresses
+export addresses
 
 type
   SocketObj = object
@@ -336,90 +337,6 @@ macro implGenericAsyncConn(): untyped =
             write(s, nil, 0)
 
 implGenericAsyncConn()
-
-type
-  IP4* = IP4Impl
-    ## An IPv4 address.
-
-func word(ip: IP4): uint32 {.inline.} =
-  ## Obtain the address from `ip` as an integer in big endian.
-  ip4Word()
-
-func `word=`(ip: var IP4, w: uint32) {.inline.} =
-  ## Set the address referenced to by `ip` to `w`, with `w` in big endian.
-  ip4SetWord()
-
-func ip4*(a, b, c, d: byte): IP4 {.inline.} =
-  ## Returns the `IP4` object of the IP address `a.b.c.d`.
-  result.word = fromBytesBE(uint32, [a, b, c, d]).toBE()
-
-const
-  IP4Loopback* = ip4(127, 0, 0, 1)
-    ## The IPv4 loopback address.
-
-  IP4Any* = ip4(0, 0, 0, 0)
-    ## The IPv4 address used to signify binding to any address.
-
-  IP4Broadcast* = ip4(255, 255, 255, 255)
-    ## The IPv4 address used to signify any host.
-
-func `==`*(a, b: IP4): bool {.inline.} =
-  ## Returns whether `a` and `b` points to the same address.
-  a.word == b.word
-
-func `[]`*(ip: IP4, idx: Natural): byte {.inline.} =
-  ## Returns octet at position `idx` of `ip`.
-  runnableExamples:
-    let ip = ip4(127, 0, 0, 1)
-    doAssert ip[0] == 127
-
-  ip.word.fromBE().toBytesBE()[idx]
-
-func `[]=`*(ip: var IP4, idx: Natural, val: byte) {.inline.} =
-  ## Set the octet at position `idx` to `val`.
-  runnableExamples:
-    var ip = ip4(127, 0, 0, 1)
-    ip[0] = 10
-    doAssert ip == ip4(10, 0, 0, 1)
-
-  var address = ip.word.fromBE().toBytesBE()
-  address[idx] = val
-  ip.word = fromBytesBE(uint32, address).toBE()
-
-func len*(ip: IP4): int {.inline.} =
-  ## Returns the number of octets in `ip`.
-  4
-
-func `$`*(ip: IP4): string {.inline.} =
-  ## Returns the string representation of `ip`.
-  result = $ip[0] & '.' & $ip[1] & '.' & $ip[2] & '.' & $ip[3]
-
-type
-  Port* = distinct uint16
-    ## The port number type.
-
-  IP4Endpoint* = IP4EndpointImpl
-    ## An IPv4 endpoint, which is a combination of an IPv4 address and a port.
-
-const
-  PortNone* = 0.Port
-    ## The port that means "no port". Different procedures will interpret this
-    ## value differently.
-
-func `$`*(p: Port): string {.borrow.}
-func `==`*(a, b: Port): bool {.borrow.}
-
-proc initEndpoint*(ip: IP4, port: Port): IP4Endpoint =
-  ## Creates an endpoint from an IP address and a port.
-  ip4InitEndpoint()
-
-proc ip*(e: IP4Endpoint): IP4 =
-  ## Returns the IPv4 address of the endpoint.
-  ip4EndpointAddr()
-
-proc port*(e: IP4Endpoint): Port =
-  ## Returns the port of the endpoint.
-  ip4EndpointPort()
 
 type
   ResolverResult* = ref ResolverResultImpl

--- a/src/sys/sockets.nim
+++ b/src/sys/sockets.nim
@@ -8,8 +8,6 @@
 
 ## Abstractions for networking operations over sockets.
 
-{.experimental: "implicitDeref".}
-
 import system except IOError
 
 import std/[genasts, macros, options]
@@ -41,14 +39,14 @@ func fd*(s: AnySocket): SocketFD {.inline.} =
   ## Returns the handle held by `s`.
   ##
   ## The returned `SocketFD` will stay valid for the duration of `s`.
-  get s.handle
+  s.handle.fd
 
 func takeFD*(s: AnySocket): SocketFD {.inline.} =
   ## Returns the file handle held by `s` and release ownership to the caller.
   ## `s` will be invalidated.
   ##
   ## If `s` is asynchronous, it will *not* be unregistered from the queue.
-  take s.handle
+  takeFd s.handle
 
 proc close(s: var SocketObj) {.inline.} =
   ## Closes and invalidates the socket `s`.
@@ -60,7 +58,7 @@ proc close(s: var AsyncSocketObj) {.inline.}
 
 proc `=destroy`(s: var AsyncSocketObj) =
   ## Destroy the asynchronous socket `s`.
-  if s.handle.get != InvalidFD:
+  if s.handle.fd != InvalidFD:
     close(s)
 
 proc close(s: var AsyncSocketObj) {.inline.} =
@@ -69,7 +67,7 @@ proc close(s: var AsyncSocketObj) {.inline.} =
   ## If `s` is invalid, `ClosedHandleDefect` will be raised.
   ##
   ## The FD associated with `s` will be deregistered from `ioqueue`.
-  unregister s.handle.get
+  unregister s.handle.fd
   close SocketObj(s)
 
 proc close*(s: Socket) {.inline.} =
@@ -260,8 +258,8 @@ macro implGenericAsyncConn(): untyped =
           ##
           ## This is an overload of read(s, buf, bufLen), plese refer to its
           ## documentation for more information.
-          if b.len > 0:
-            read(s, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+          if b[].len > 0:
+            read(s, cast[ptr UncheckedArray[byte]](addr b[][0]), b[].len)
           else:
             read(s, nil, 0)
 
@@ -270,8 +268,8 @@ macro implGenericAsyncConn(): untyped =
           ##
           ## This is an overload of read(s, buf, bufLen), plese refer to its
           ## documentation for more information.
-          if b.len > 0:
-            read(s, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+          if b[].len > 0:
+            read(s, cast[ptr UncheckedArray[byte]](addr b[][0]), b[].len)
           else:
             read(s, nil, 0)
 
@@ -322,8 +320,8 @@ macro implGenericAsyncConn(): untyped =
           ##
           ## This is an overload of write(s, buf, bufLen), plese refer to its
           ## documentation for more information.
-          if b.len > 0:
-            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[0]), b.len)
+          if b[].len > 0:
+            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[][0]), b[].len)
           else:
             write(s, nil, 0)
 
@@ -332,8 +330,8 @@ macro implGenericAsyncConn(): untyped =
           ##
           ## This is an overload of write(s, buf, bufLen), plese refer to its
           ## documentation for more information.
-          if b.len > 0:
-            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[0]), b.len)
+          if b[].len > 0:
+            write(s, cast[ptr UncheckedArray[byte]](unsafeAddr b[][0]), b[].len)
           else:
             write(s, nil, 0)
 

--- a/src/sys/sockets/addresses.nim
+++ b/src/sys/sockets/addresses.nim
@@ -1,0 +1,102 @@
+#
+#            Abstractions for operating system services
+#                   Copyright (c) 2021 Leorize
+#
+# Licensed under the terms of the MIT license which can be found in
+# the file "license.txt" included with this distribution. Alternatively,
+# the full text can be found at: https://spdx.org/licenses/MIT.html
+
+## Addresses and related utilities
+
+import pkg/stew/endians2
+
+when defined(posix):
+  include ".."/private/addresses_posix
+elif defined(windows):
+  include ".."/private/addresses_windows
+else:
+  {.error: "This module has not been ported to your operating system.".}
+
+type
+  IP4* = IP4Impl
+    ## An IPv4 address.
+
+func word(ip: IP4): uint32 {.inline.} =
+  ## Obtain the address from `ip` as an integer in big endian.
+  ip4Word()
+
+func `word=`(ip: var IP4, w: uint32) {.inline.} =
+  ## Set the address referenced to by `ip` to `w`, with `w` in big endian.
+  ip4SetWord()
+
+func ip4*(a, b, c, d: byte): IP4 {.inline.} =
+  ## Returns the `IP4` object of the IP address `a.b.c.d`.
+  result.word = fromBytesBE(uint32, [a, b, c, d]).toBE()
+
+const
+  IP4Loopback* = ip4(127, 0, 0, 1)
+    ## The IPv4 loopback address.
+
+  IP4Any* = ip4(0, 0, 0, 0)
+    ## The IPv4 address used to signify binding to any address.
+
+  IP4Broadcast* = ip4(255, 255, 255, 255)
+    ## The IPv4 address used to signify any host.
+
+func `==`*(a, b: IP4): bool {.inline.} =
+  ## Returns whether `a` and `b` points to the same address.
+  a.word == b.word
+
+func `[]`*(ip: IP4, idx: Natural): byte {.inline.} =
+  ## Returns octet at position `idx` of `ip`.
+  runnableExamples:
+    let ip = ip4(127, 0, 0, 1)
+    doAssert ip[0] == 127
+
+  ip.word.fromBE().toBytesBE()[idx]
+
+func `[]=`*(ip: var IP4, idx: Natural, val: byte) {.inline.} =
+  ## Set the octet at position `idx` to `val`.
+  runnableExamples:
+    var ip = ip4(127, 0, 0, 1)
+    ip[0] = 10
+    doAssert ip == ip4(10, 0, 0, 1)
+
+  var address = ip.word.fromBE().toBytesBE()
+  address[idx] = val
+  ip.word = fromBytesBE(uint32, address).toBE()
+
+func len*(ip: IP4): int {.inline.} =
+  ## Returns the number of octets in `ip`.
+  4
+
+func `$`*(ip: IP4): string {.inline.} =
+  ## Returns the string representation of `ip`.
+  result = $ip[0] & '.' & $ip[1] & '.' & $ip[2] & '.' & $ip[3]
+
+type
+  Port* = distinct uint16
+    ## The port number type.
+
+  IP4Endpoint* = IP4EndpointImpl
+    ## An IPv4 endpoint, which is a combination of an IPv4 address and a port.
+
+const
+  PortNone* = 0.Port
+    ## The port that means "no port". Different procedures will interpret this
+    ## value differently.
+
+func `$`*(p: Port): string {.borrow.}
+func `==`*(a, b: Port): bool {.borrow.}
+
+proc initEndpoint*(ip: IP4, port: Port): IP4Endpoint =
+  ## Creates an endpoint from an IP address and a port.
+  ip4InitEndpoint()
+
+proc ip*(e: IP4Endpoint): IP4 =
+  ## Returns the IPv4 address of the endpoint.
+  ip4EndpointAddr()
+
+proc port*(e: IP4Endpoint): Port =
+  ## Returns the port of the endpoint.
+  ip4EndpointPort()

--- a/sys.nimble
+++ b/sys.nimble
@@ -15,6 +15,7 @@ when (NimMajor, NimMinor, NimPatch) < (1, 9, 0):
   requires "https://github.com/nim-works/cps >= 0.8.0 & < 0.9.0"
 else:
   requires "https://github.com/nim-works/cps >= 0.9.0 & < 0.10.0"
+requires "https://github.com/status-im/nim-stew#3c91b8694e15137a81ec7db37c6c58194ec94a6a"
 
 # Bundled as submodule instead since the package can only be installed on Windows.
 # requires "https://github.com/khchen/winim#bffaf742b4603d1f675b4558d250d5bfeb8b6630"

--- a/tests/helpers/io.nim
+++ b/tests/helpers/io.nim
@@ -9,6 +9,18 @@
 import std/strutils
 import sys/ioqueue
 
+const Delimiter* = "\c\l\c\l"
+  # The HTTP delimiter
+
+let
+  TestBufferedData* = "!@#$%^TEST%$#@!\n".repeat(2_000_000)
+    ## A decently sized buffer that surpasses most OS pipe buffer size, which
+    ## is usually in the range of 4-8MiB.
+    ##
+    ## Declared as a `let` to avoid binary size being inflated by the inlining.
+  TestDelimitedData* = TestBufferedData & Delimiter
+    ## The buffer used to test delimited reads.
+
 proc accumlatedRead*[T](readable: T, size: Natural): string =
   ## Read until a buffer of `size` is reached or EOF is received.
   ##

--- a/tests/sockets/tip.nim
+++ b/tests/sockets/tip.nim
@@ -1,16 +1,15 @@
-when defined(posix):
-  import pkg/balls
-  import sys/sockets
+import pkg/balls
+import sys/sockets
 
-  suite "IP address testing":
-    test "IPv4 to string":
-      check $ip4(127, 0, 0, 1) == "127.0.0.1"
-      check $ip4(1, 1, 1, 1) == "1.1.1.1"
+suite "IP address testing":
+  test "IPv4 to string":
+    check $ip4(127, 0, 0, 1) == "127.0.0.1"
+    check $ip4(1, 1, 1, 1) == "1.1.1.1"
 
-    test "Resolving localhost works":
-      block test:
-        for ep in resolveIP4("localhost").items:
-          if ep.ip == ip4(127, 0, 0, 1):
-            break test
+  test "Resolving localhost works":
+    block test:
+      for ep in resolveIP4("localhost").items:
+        if ep.ip == ip4(127, 0, 0, 1):
+          break test
 
-        check false, "did not find 127.0.0.1 when resolving for localhost"
+      check false, "did not find 127.0.0.1 when resolving for localhost"

--- a/tests/sockets/tip.nim
+++ b/tests/sockets/tip.nim
@@ -1,0 +1,16 @@
+when defined(posix):
+  import pkg/balls
+  import sys/sockets
+
+  suite "IP address testing":
+    test "IPv4 to string":
+      check $ip4(127, 0, 0, 1) == "127.0.0.1"
+      check $ip4(1, 1, 1, 1) == "1.1.1.1"
+
+    test "Resolving localhost works":
+      block test:
+        for ep in resolveIP4("localhost").items:
+          if ep.ip == ip4(127, 0, 0, 1):
+            break test
+
+        check false, "did not find 127.0.0.1 when resolving for localhost"

--- a/tests/sockets/tsockets.nim
+++ b/tests/sockets/tsockets.nim
@@ -57,6 +57,22 @@ when defined(posix):
       checkAsync()
       run()
 
+    test "Listener[TCP] listening on same endpoint error":
+      let server = listenTcp(IP4Loopback, PortNone)
+
+      expect OSError:
+        discard listenTcp(server.localEndpoint)
+
+    test "AsyncListener[TCP] listening on same endpoint error":
+      proc runner() {.asyncio.} =
+        let server = listenTcpAsync(IP4Loopback, PortNone)
+
+        expect OSError:
+          discard listenTcpAsync(server.localEndpoint)
+
+      runner()
+      run()
+
     test "Conn[TCP] EOF read":
       proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
         ## A server that accept a connection then drops it

--- a/tests/sockets/tsockets.nim
+++ b/tests/sockets/tsockets.nim
@@ -1,0 +1,390 @@
+when defined(posix):
+  import std/[locks, strutils]
+  import pkg/balls
+  import sys/[files, ioqueue, sockets]
+  import ".."/helpers/io
+
+  makeAccRead(AsyncConn[TCP])
+  makeAccWrite(AsyncConn[TCP])
+  makeDelimRead(AsyncConn[TCP])
+
+  suite "TCP sockets":
+    test "Listening on TCP port 0 will create a random port":
+      let server = listenTcp(IP4Loopback, PortNone)
+      check server.localEndpoint.port != PortNone
+
+      proc checkAsync() {.asyncio.} =
+        let asyncServer = listenTcpAsync(IP4Loopback, PortNone)
+        check asyncServer.localEndpoint.port != PortNone
+        check asyncServer.localEndpoint.port != server.localEndpoint.port
+
+      checkAsync()
+      run()
+
+    test "Listening/connecting on/to localhost":
+      # The main point of this test is to make sure that the name-based API works.
+      proc acceptWorker(s: ptr Listener[TCP]) {.thread.} =
+        {.gcsafe.}:
+          # Accept then close connection immediately
+          close s[].accept().conn
+
+      var server = listenTcp("localhost", PortNone)
+      check server.localEndpoint.port != PortNone
+      var thr: Thread[ptr Listener[TCP]]
+      thr.createThread(acceptWorker, addr server)
+
+      # Connect then disconnect immediately
+      close connectTcp("localhost", server.localEndpoint.port)
+
+      # Close the thread
+      joinThread thr
+
+      proc acceptWorker(s: AsyncListener[TCP]) {.asyncio.} =
+        # Accept then close connection immediately
+        close s.accept().conn
+
+      proc checkAsync() {.asyncio.} =
+        let asyncServer = listenTcpAsync("localhost", PortNone)
+        # Run until the worker dismisses to the background
+        discard trampoline:
+          whelp acceptWorker(asyncServer)
+
+        check asyncServer.localEndpoint.port != PortNone
+        check asyncServer.localEndpoint.port != server.localEndpoint.port
+        # Connect then disconnect immediately
+        close connectTcpAsync("localhost", asyncServer.localEndpoint.port)
+
+      checkAsync()
+      run()
+
+    test "Conn[TCP] EOF read":
+      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+        ## A server that accept a connection then drops it
+        ## immediately
+        {.gcsafe.}:
+          close srv[].accept().conn
+
+      var server = listenTcp(IP4Loopback, PortNone)
+      var thr: Thread[ptr Listener[TCP]]
+      # Launch a thread to act as the server accepting connections.
+      thr.createThread(acceptWorker, addr server)
+
+      # Connect to the server
+      let client = connectTcp(server.localEndpoint)
+      # Wait until the worker stops
+      joinThread(thr)
+
+      # Our connection should be dropped and reading should yields nothing.
+      var str = newString(10)
+      check client.read(str) == 0
+
+    test "Conn[TCP] EOF write":
+      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+        ## A server that accept a connection then drops it
+        ## immediately
+        {.gcsafe.}:
+          close srv[].accept().conn
+
+      var server = listenTcp(IP4Loopback, PortNone)
+      var thr: Thread[ptr Listener[TCP]]
+      # Launch a thread to act as the server accepting connections.
+      thr.createThread(acceptWorker, addr server)
+
+      # Connect to the server
+      let client = connectTcp(server.localEndpoint)
+      # Wait until the worker stops
+      joinThread(thr)
+
+      # Our connection should be dropped and writing should error.
+      #
+      # It is expected that there might be some data written due
+      # to operating system maintaining a local buffer.
+      expect files.IOError:
+        # Some repeats will be necessary as some operating systems buffers data
+        # and won't trigger a send immediately, thus not raising the error.
+        for _ in 1 .. 10:
+          discard client.write("test data")
+
+    test "Conn[TCP] zero read":
+      var l: Lock
+      initLock(l)
+
+      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+        ## A server that accept a connection then write some small data into it.
+        {.gcsafe.}:
+          let (conn, _) = srv[].accept()
+          # Write something to not cause a block
+          discard conn.write("  ")
+          # Wait until the caller is done with their work
+          withLock(l):
+            discard
+
+      var server = listenTcp(IP4Loopback, PortNone)
+      var thr: Thread[ptr Listener[TCP]]
+      # Hold the lock so the worker won't terminate
+      withLock l:
+        # Launch a thread to act as the server accepting connections.
+        thr.createThread(acceptWorker, addr server)
+
+        # Connect to the server
+        let client = connectTcp(server.localEndpoint)
+
+        var str = newString(0)
+        check client.read(str) == 0
+
+      # Wait until the worker stops
+      joinThread(thr)
+      deinitLock(l)
+
+    test "Conn[TCP] zero write":
+      var l: Lock
+      initLock(l)
+
+      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+        ## A server that accept a connection then write some small data into it.
+        {.gcsafe.}:
+          let (conn, _) = srv[].accept()
+          # Wait until the caller is done with their work
+          withLock l:
+            discard
+
+      var server = listenTcp(IP4Loopback, PortNone)
+      var thr: Thread[ptr Listener[TCP]]
+      # Hold the lock so the worker won't terminate
+      withLock l:
+        # Launch a thread to act as the server accepting connections.
+        thr.createThread(acceptWorker, addr server)
+
+        # Connect to the server
+        let client = connectTcp(server.localEndpoint)
+
+        check client.write("") == 0
+
+      # Wait until the worker stops
+      joinThread(thr)
+      deinitLock(l)
+
+    test "Conn[TCP] long read/write":
+      proc writeWorker(server: ptr Listener[TCP]) {.thread.} =
+        ## Accepts a connection then write test data to it, closing it afterwards
+        {.gcsafe.}:
+          let (conn, _) = server[].accept()
+          # Send the sample data
+          conn.accumlatedWrite TestBufferedData
+          # Shutdown the connection to signal completion
+          close conn
+
+      # Creates the server
+      var server = listenTcp(IP4Loopback, PortNone)
+      var thr: Thread[ptr Listener[TCP]]
+      thr.createThread(writeWorker, addr server)
+
+      # Connect to the server
+      let conn = connectTcp(server.localEndpoint)
+
+      # Retrieve the data
+      check conn.accumlatedRead(TestBufferedData.len + 1024) == TestBufferedData
+
+      # Wait for the worker to terminate
+      thr.joinThread()
+
+    test "Conn[TCP] delimited read/write":
+      proc writeWorker(server: ptr Listener[TCP]) {.thread.} =
+        ## Accepts a connection then write test data to it, closing it afterwards
+        {.gcsafe.}:
+          let (conn, _) = server[].accept()
+          # Send the sample data
+          conn.accumlatedWrite TestDelimitedData
+
+      var server = listenTcp(IP4Loopback, PortNone)
+      var thr: Thread[ptr Listener[TCP]]
+      thr.createThread(writeWorker, addr server)
+
+      # Connect to the server
+      let conn = connectTcp(server.localEndpoint)
+
+      # Read from the server and verify the data
+      check conn.delimitedRead(Delimiter) == TestDelimitedData
+
+      # Collect the writer
+      joinThread thr
+
+    test "AsyncConn[TCP] EOF read":
+      proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
+        ## A server that accept a connection then drops it
+        ## immediately
+        close server.accept().conn
+
+      proc runner() {.asyncio.} =
+        let server = listenTcpAsync(IP4Loopback, PortNone)
+        # Run the worker until it is dismissed
+        discard trampoline:
+          whelp acceptWorker(server)
+
+        # Connect to the server
+        let client = connectTcpAsync(server.localEndpoint)
+
+        # Our connection should be dropped and reading should yields nothing.
+        var str = new string
+        str[] = newString(10)
+        check client.read(str) == 0
+
+      # Start the test
+      runner()
+      # Run the IO queue to completion
+      run()
+
+    test "AsyncConn[TCP] EOF write":
+      # After many tries Linux just keep reporting EWOULDBLOCK.
+      #
+      # This is likely to be the same on other OS, this behavior can't be
+      # relied upon.
+      skip "Unable to confirm the behavior under Linux"
+
+      proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
+        ## A server that accept a connection then drops it
+        ## immediately
+        close server.accept().conn
+
+      proc runner() {.asyncio.} =
+        var server = listenTcpAsync(IP4Loopback, PortNone)
+        # Run the worker until it is dismissed
+        discard trampoline:
+          whelp acceptWorker(server)
+
+        # Connect to the server
+        let client = connectTcpAsync(server.localEndpoint)
+
+        # Our connection should be dropped and writing should error.
+        #
+        # It is expected that there might be some data written due
+        # to operating system maintaining a local buffer.
+        expect files.IOError:
+          # Some repeats will be necessary as some operating systems buffers
+          # data and won't trigger a send immediately, thus not raising the
+          # error.
+          var i = 0
+          while i < 10:
+            discard client.write("test data")
+            inc i
+
+      # Start the test
+      runner()
+      # Run the IO queue to completion
+      run()
+
+    test "AsyncConn[TCP] zero read":
+      proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
+        ## A server that accept a connection then drops it
+        ## immediately
+        close server.accept().conn
+
+      proc runner() {.asyncio.} =
+        let server = listenTcpAsync(IP4Loopback, PortNone)
+        # Run the worker until it is dismissed
+        discard trampoline:
+          whelp acceptWorker(server)
+
+        # Connect to the server
+        let client = connectTcpAsync(server.localEndpoint)
+
+        var str = new string
+        check client.read(str) == 0
+
+        var sq = new string
+        check client.read(sq) == 0
+
+        check client.read(nil, 0) == 0
+
+      # Start the test
+      runner()
+      # Run the IO queue to completion
+      run()
+
+    test "AsyncConn[TCP] zero write":
+      proc acceptWorker(server: AsyncListener[TCP]): AsyncConn[TCP] {.asyncio.} =
+        ## A server that accept a connection
+        # Return it so it won't get closed immediately
+        result = server.accept().conn
+
+      proc runner() {.asyncio.} =
+        let server = listenTcpAsync(IP4Loopback, PortNone)
+        # Keep a reference to the worker so we can keep the connection alive
+        let worker = whelp acceptWorker(server)
+        # Tramp it
+        discard trampoline worker
+
+        # Connect to the server
+        let client = connectTcpAsync(server.localEndpoint)
+
+        check client.write("") == 0
+        check client.write(default seq[byte]) == 0
+
+        var str = new string
+        check client.write(str) == 0
+
+        var sq = new seq[byte]
+        check client.write(sq) == 0
+
+        check client.write(nil, 0) == 0
+
+      # Start the test
+      runner()
+      # Run the IO queue to completion
+      run()
+
+    test "AsyncConn[TCP] read/write":
+      proc writeWorker(server: AsyncListener[TCP]) {.asyncio.} =
+        ## Accepts a connection then write test data to it, closing it afterwards
+        let (conn, _) = server.accept()
+        # Send the sample data
+        conn.accumlatedWrite TestBufferedData
+
+        # Close to signal completion
+        close conn
+
+      proc runner() {.asyncio.} =
+        # Creates the server
+        var server = listenTcpAsync(IP4Loopback, PortNone)
+        # Run the worker until it is dismissed
+        discard trampoline:
+          whelp writeWorker(server)
+
+        # Connect to the server
+        let conn = connectTcpAsync(server.localEndpoint)
+
+        # Retrieve the data
+        check conn.accumlatedRead(TestBufferedData.len + 1024) == TestBufferedData
+
+      # Run the test
+      runner()
+      # Run the IO queue to completion
+      run()
+
+    test "AsyncConn[TCP] delimited read / write":
+      proc writeWorker(server: AsyncListener[TCP]) {.asyncio.} =
+        ## Accepts a connection then write test data to it, closing it afterwards
+        let (conn, _) = server.accept()
+        # Send the sample data
+        conn.accumlatedWrite TestDelimitedData
+
+        # Close to signal completion
+        close conn
+
+      proc runner() {.asyncio.} =
+        # Creates the server
+        var server = listenTcpAsync(IP4Loopback, PortNone)
+        # Run the worker until it is dismissed
+        discard trampoline:
+          whelp writeWorker(server)
+
+        # Connect to the server
+        let conn = connectTcpAsync(server.localEndpoint)
+
+        # Retrieve the data
+        check conn.delimitedRead(Delimiter) == TestDelimitedData
+
+      # Run the test
+      runner()
+      # Run the IO queue to completion
+      run()

--- a/tests/sockets/tsockets.nim
+++ b/tests/sockets/tsockets.nim
@@ -1,400 +1,399 @@
-when defined(posix):
-  import std/[locks, strutils]
-  import pkg/balls
-  import sys/[files, ioqueue, sockets]
-  import ".."/helpers/io
+import std/[locks, strutils]
+import pkg/balls
+import sys/[files, ioqueue, sockets]
+import ".."/helpers/io
 
-  makeAccRead(AsyncConn[TCP])
-  makeAccWrite(AsyncConn[TCP])
-  makeDelimRead(AsyncConn[TCP])
+makeAccRead(AsyncConn[TCP])
+makeAccWrite(AsyncConn[TCP])
+makeDelimRead(AsyncConn[TCP])
 
-  suite "TCP sockets":
-    test "Listening on TCP port 0 will create a random port":
-      let server = listenTcp(IP4Loopback, PortNone)
-      check server.localEndpoint.port != PortNone
+suite "TCP sockets":
+  test "Listening on TCP port 0 will create a random port":
+    let server = listenTcp(IP4Loopback, PortNone)
+    check server.localEndpoint.port != PortNone
 
-      proc checkAsync() {.asyncio.} =
-        let asyncServer = listenTcpAsync(IP4Loopback, PortNone)
-        check asyncServer.localEndpoint.port != PortNone
-        check asyncServer.localEndpoint.port != server.localEndpoint.port
+    proc checkAsync() {.asyncio.} =
+      let asyncServer = listenTcpAsync(IP4Loopback, PortNone)
+      check asyncServer.localEndpoint.port != PortNone
+      check asyncServer.localEndpoint.port != server.localEndpoint.port
 
-      checkAsync()
-      run()
+    checkAsync()
+    run()
 
-    test "Listening/connecting on/to localhost":
-      # The main point of this test is to make sure that the name-based API works.
-      proc acceptWorker(s: ptr Listener[TCP]) {.thread.} =
-        {.gcsafe.}:
-          # Accept then close connection immediately
-          close s[].accept().conn
-
-      var server = listenTcp("localhost", PortNone)
-      check server.localEndpoint.port != PortNone
-      var thr: Thread[ptr Listener[TCP]]
-      thr.createThread(acceptWorker, addr server)
-
-      # Connect then disconnect immediately
-      close connectTcp("localhost", server.localEndpoint.port)
-
-      # Close the thread
-      joinThread thr
-
-      proc acceptWorker(s: AsyncListener[TCP]) {.asyncio.} =
+  test "Listening/connecting on/to localhost":
+    # The main point of this test is to make sure that the name-based API works.
+    proc acceptWorker(s: ptr Listener[TCP]) {.thread.} =
+      {.gcsafe.}:
         # Accept then close connection immediately
-        close s.accept().conn
+        close s[].accept().conn
 
-      proc checkAsync() {.asyncio.} =
-        let asyncServer = listenTcpAsync("localhost", PortNone)
-        # Run until the worker dismisses to the background
-        discard trampoline:
-          whelp acceptWorker(asyncServer)
+    var server = listenTcp("localhost", PortNone)
+    check server.localEndpoint.port != PortNone
+    var thr: Thread[ptr Listener[TCP]]
+    thr.createThread(acceptWorker, addr server)
 
-        check asyncServer.localEndpoint.port != PortNone
-        check asyncServer.localEndpoint.port != server.localEndpoint.port
-        # Connect then disconnect immediately
-        close connectTcpAsync("localhost", asyncServer.localEndpoint.port)
+    # Connect then disconnect immediately
+    close connectTcp("localhost", server.localEndpoint.port)
 
-      checkAsync()
-      run()
+    # Close the thread
+    joinThread thr
 
-    test "Listener[TCP] listening on same endpoint error":
-      let server = listenTcp(IP4Loopback, PortNone)
+    proc acceptWorker(s: AsyncListener[TCP]) {.asyncio.} =
+      # Accept then close connection immediately
+      close s.accept().conn
+
+    proc checkAsync() {.asyncio.} =
+      let asyncServer = listenTcpAsync("localhost", PortNone)
+      # Run until the worker dismisses to the background
+      discard trampoline:
+        whelp acceptWorker(asyncServer)
+
+      check asyncServer.localEndpoint.port != PortNone
+      check asyncServer.localEndpoint.port != server.localEndpoint.port
+      # Connect then disconnect immediately
+      close connectTcpAsync("localhost", asyncServer.localEndpoint.port)
+
+    checkAsync()
+    run()
+
+  test "Listener[TCP] listening on same endpoint error":
+    let server = listenTcp(IP4Loopback, PortNone)
+
+    expect OSError:
+      discard listenTcp(server.localEndpoint)
+
+  test "AsyncListener[TCP] listening on same endpoint error":
+    proc runner() {.asyncio.} =
+      let server = listenTcpAsync(IP4Loopback, PortNone)
 
       expect OSError:
-        discard listenTcp(server.localEndpoint)
+        discard listenTcpAsync(server.localEndpoint)
 
-    test "AsyncListener[TCP] listening on same endpoint error":
-      proc runner() {.asyncio.} =
-        let server = listenTcpAsync(IP4Loopback, PortNone)
+    runner()
+    run()
 
-        expect OSError:
-          discard listenTcpAsync(server.localEndpoint)
+  test "Conn[TCP] EOF read":
+    proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+      ## A server that accept a connection then drops it
+      ## immediately
+      {.gcsafe.}:
+        close srv[].accept().conn
 
-      runner()
-      run()
+    var server = listenTcp(IP4Loopback, PortNone)
+    var thr: Thread[ptr Listener[TCP]]
+    # Launch a thread to act as the server accepting connections.
+    thr.createThread(acceptWorker, addr server)
 
-    test "Conn[TCP] EOF read":
-      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
-        ## A server that accept a connection then drops it
-        ## immediately
-        {.gcsafe.}:
-          close srv[].accept().conn
+    # Connect to the server
+    let client = connectTcp(server.localEndpoint)
+    # Wait until the worker stops
+    joinThread(thr)
 
-      var server = listenTcp(IP4Loopback, PortNone)
-      var thr: Thread[ptr Listener[TCP]]
+    # Our connection should be dropped and reading should yields nothing.
+    var str = newString(10)
+    check client.read(str) == 0
+
+  test "Conn[TCP] EOF write with big buffers":
+    proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+      ## A server that accept a connection then drops it
+      ## immediately
+      {.gcsafe.}:
+        close srv[].accept().conn
+
+    var server = listenTcp(IP4Loopback, PortNone)
+    var thr: Thread[ptr Listener[TCP]]
+    # Launch a thread to act as the server accepting connections.
+    thr.createThread(acceptWorker, addr server)
+
+    # Connect to the server
+    let client = connectTcp(server.localEndpoint)
+    # Wait until the worker stops
+    joinThread(thr)
+
+    # Our connection should be dropped and writing should error.
+    #
+    # It is expected that there might be some data written due
+    # to operating system maintaining a local buffer.
+    expect files.IOError:
+      # Some repeats will be necessary as some operating systems buffers data
+      # and won't trigger a send immediately, thus not raising the error.
+      for _ in 1 .. 10:
+        discard client.write(TestBufferedData)
+
+  test "Conn[TCP] zero read":
+    var l: Lock
+    initLock(l)
+
+    proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+      ## A server that accept a connection then write some small data into it.
+      {.gcsafe.}:
+        let (conn, _) = srv[].accept()
+        # Write something to not cause a block
+        discard conn.write("  ")
+        # Wait until the caller is done with their work
+        withLock(l):
+          discard
+
+    var server = listenTcp(IP4Loopback, PortNone)
+    var thr: Thread[ptr Listener[TCP]]
+    # Hold the lock so the worker won't terminate
+    withLock l:
       # Launch a thread to act as the server accepting connections.
       thr.createThread(acceptWorker, addr server)
 
       # Connect to the server
       let client = connectTcp(server.localEndpoint)
-      # Wait until the worker stops
-      joinThread(thr)
 
-      # Our connection should be dropped and reading should yields nothing.
-      var str = newString(10)
+      var str = newString(0)
       check client.read(str) == 0
 
-    test "Conn[TCP] EOF write with big buffers":
-      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
-        ## A server that accept a connection then drops it
-        ## immediately
-        {.gcsafe.}:
-          close srv[].accept().conn
+    # Wait until the worker stops
+    joinThread(thr)
+    deinitLock(l)
 
-      var server = listenTcp(IP4Loopback, PortNone)
-      var thr: Thread[ptr Listener[TCP]]
+  test "Conn[TCP] zero write":
+    var l: Lock
+    initLock(l)
+
+    proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
+      ## A server that accept a connection then write some small data into it.
+      {.gcsafe.}:
+        let (conn, _) = srv[].accept()
+        # Wait until the caller is done with their work
+        withLock l:
+          discard
+
+    var server = listenTcp(IP4Loopback, PortNone)
+    var thr: Thread[ptr Listener[TCP]]
+    # Hold the lock so the worker won't terminate
+    withLock l:
       # Launch a thread to act as the server accepting connections.
       thr.createThread(acceptWorker, addr server)
 
       # Connect to the server
       let client = connectTcp(server.localEndpoint)
-      # Wait until the worker stops
-      joinThread(thr)
+
+      check client.write("") == 0
+
+    # Wait until the worker stops
+    joinThread(thr)
+    deinitLock(l)
+
+  test "Conn[TCP] long read/write":
+    proc writeWorker(server: ptr Listener[TCP]) {.thread.} =
+      ## Accepts a connection then write test data to it, closing it afterwards
+      {.gcsafe.}:
+        let (conn, _) = server[].accept()
+        # Send the sample data
+        conn.accumlatedWrite TestBufferedData
+        # Shutdown the connection to signal completion
+        close conn
+
+    # Creates the server
+    var server = listenTcp(IP4Loopback, PortNone)
+    var thr: Thread[ptr Listener[TCP]]
+    thr.createThread(writeWorker, addr server)
+
+    # Connect to the server
+    let conn = connectTcp(server.localEndpoint)
+
+    # Retrieve the data
+    check conn.accumlatedRead(TestBufferedData.len + 1024) == TestBufferedData
+
+    # Wait for the worker to terminate
+    thr.joinThread()
+
+  test "Conn[TCP] delimited read/write":
+    proc writeWorker(server: ptr Listener[TCP]) {.thread.} =
+      ## Accepts a connection then write test data to it, closing it afterwards
+      {.gcsafe.}:
+        let (conn, _) = server[].accept()
+        # Send the sample data
+        conn.accumlatedWrite TestDelimitedData
+
+    var server = listenTcp(IP4Loopback, PortNone)
+    var thr: Thread[ptr Listener[TCP]]
+    thr.createThread(writeWorker, addr server)
+
+    # Connect to the server
+    let conn = connectTcp(server.localEndpoint)
+
+    # Read from the server and verify the data
+    check conn.delimitedRead(Delimiter) == TestDelimitedData
+
+    # Collect the writer
+    joinThread thr
+
+  test "AsyncConn[TCP] EOF read":
+    proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
+      ## A server that accept a connection then drops it
+      ## immediately
+      close server.accept().conn
+
+    proc runner() {.asyncio.} =
+      let server = listenTcpAsync(IP4Loopback, PortNone)
+      # Run the worker until it is dismissed
+      discard trampoline:
+        whelp acceptWorker(server)
+
+      # Connect to the server
+      let client = connectTcpAsync(server.localEndpoint)
+
+      # Our connection should be dropped and reading should yields nothing.
+      var str = new string
+      str[] = newString(10)
+      check client.read(str) == 0
+
+    # Start the test
+    runner()
+    # Run the IO queue to completion
+    run()
+
+  test "AsyncConn[TCP] EOF write with big buffers":
+    proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
+      ## A server that accept a connection then drops it
+      ## immediately
+      close server.accept().conn
+
+    proc runner() {.asyncio.} =
+      var server = listenTcpAsync(IP4Loopback, PortNone)
+      # Run the worker until it is dismissed
+      discard trampoline:
+        whelp acceptWorker(server)
+
+      # Connect to the server
+      let client = connectTcpAsync(server.localEndpoint)
 
       # Our connection should be dropped and writing should error.
       #
       # It is expected that there might be some data written due
       # to operating system maintaining a local buffer.
       expect files.IOError:
-        # Some repeats will be necessary as some operating systems buffers data
-        # and won't trigger a send immediately, thus not raising the error.
-        for _ in 1 .. 10:
+        # Some repeats will be necessary as some operating systems buffers
+        # data and won't trigger a send immediately, thus not raising the
+        # error.
+        var i = 0
+        while i < 10:
           discard client.write(TestBufferedData)
+          inc i
 
-    test "Conn[TCP] zero read":
-      var l: Lock
-      initLock(l)
+    # Start the test
+    runner()
+    # Run the IO queue to completion
+    run()
 
-      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
-        ## A server that accept a connection then write some small data into it.
-        {.gcsafe.}:
-          let (conn, _) = srv[].accept()
-          # Write something to not cause a block
-          discard conn.write("  ")
-          # Wait until the caller is done with their work
-          withLock(l):
-            discard
+  test "AsyncConn[TCP] zero read":
+    proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
+      ## A server that accept a connection then drops it
+      ## immediately
+      close server.accept().conn
 
-      var server = listenTcp(IP4Loopback, PortNone)
-      var thr: Thread[ptr Listener[TCP]]
-      # Hold the lock so the worker won't terminate
-      withLock l:
-        # Launch a thread to act as the server accepting connections.
-        thr.createThread(acceptWorker, addr server)
-
-        # Connect to the server
-        let client = connectTcp(server.localEndpoint)
-
-        var str = newString(0)
-        check client.read(str) == 0
-
-      # Wait until the worker stops
-      joinThread(thr)
-      deinitLock(l)
-
-    test "Conn[TCP] zero write":
-      var l: Lock
-      initLock(l)
-
-      proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
-        ## A server that accept a connection then write some small data into it.
-        {.gcsafe.}:
-          let (conn, _) = srv[].accept()
-          # Wait until the caller is done with their work
-          withLock l:
-            discard
-
-      var server = listenTcp(IP4Loopback, PortNone)
-      var thr: Thread[ptr Listener[TCP]]
-      # Hold the lock so the worker won't terminate
-      withLock l:
-        # Launch a thread to act as the server accepting connections.
-        thr.createThread(acceptWorker, addr server)
-
-        # Connect to the server
-        let client = connectTcp(server.localEndpoint)
-
-        check client.write("") == 0
-
-      # Wait until the worker stops
-      joinThread(thr)
-      deinitLock(l)
-
-    test "Conn[TCP] long read/write":
-      proc writeWorker(server: ptr Listener[TCP]) {.thread.} =
-        ## Accepts a connection then write test data to it, closing it afterwards
-        {.gcsafe.}:
-          let (conn, _) = server[].accept()
-          # Send the sample data
-          conn.accumlatedWrite TestBufferedData
-          # Shutdown the connection to signal completion
-          close conn
-
-      # Creates the server
-      var server = listenTcp(IP4Loopback, PortNone)
-      var thr: Thread[ptr Listener[TCP]]
-      thr.createThread(writeWorker, addr server)
+    proc runner() {.asyncio.} =
+      let server = listenTcpAsync(IP4Loopback, PortNone)
+      # Run the worker until it is dismissed
+      discard trampoline:
+        whelp acceptWorker(server)
 
       # Connect to the server
-      let conn = connectTcp(server.localEndpoint)
+      let client = connectTcpAsync(server.localEndpoint)
+
+      var str = new string
+      check client.read(str) == 0
+
+      var sq = new string
+      check client.read(sq) == 0
+
+      check client.read(nil, 0) == 0
+
+    # Start the test
+    runner()
+    # Run the IO queue to completion
+    run()
+
+  test "AsyncConn[TCP] zero write":
+    proc acceptWorker(server: AsyncListener[TCP]): AsyncConn[TCP] {.asyncio.} =
+      ## A server that accept a connection
+      # Return it so it won't get closed immediately
+      result = server.accept().conn
+
+    proc runner() {.asyncio.} =
+      let server = listenTcpAsync(IP4Loopback, PortNone)
+      # Keep a reference to the worker so we can keep the connection alive
+      let worker = whelp acceptWorker(server)
+      # Tramp it
+      discard trampoline worker
+
+      # Connect to the server
+      let client = connectTcpAsync(server.localEndpoint)
+
+      check client.write("") == 0
+      check client.write(default seq[byte]) == 0
+
+      var str = new string
+      check client.write(str) == 0
+
+      var sq = new seq[byte]
+      check client.write(sq) == 0
+
+      check client.write(nil, 0) == 0
+
+    # Start the test
+    runner()
+    # Run the IO queue to completion
+    run()
+
+  test "AsyncConn[TCP] read/write":
+    proc writeWorker(server: AsyncListener[TCP]) {.asyncio.} =
+      ## Accepts a connection then write test data to it, closing it afterwards
+      let (conn, _) = server.accept()
+      # Send the sample data
+      conn.accumlatedWrite TestBufferedData
+
+      # Close to signal completion
+      close conn
+
+    proc runner() {.asyncio.} =
+      # Creates the server
+      var server = listenTcpAsync(IP4Loopback, PortNone)
+      # Run the worker until it is dismissed
+      discard trampoline:
+        whelp writeWorker(server)
+
+      # Connect to the server
+      let conn = connectTcpAsync(server.localEndpoint)
 
       # Retrieve the data
       check conn.accumlatedRead(TestBufferedData.len + 1024) == TestBufferedData
 
-      # Wait for the worker to terminate
-      thr.joinThread()
+    # Run the test
+    runner()
+    # Run the IO queue to completion
+    run()
 
-    test "Conn[TCP] delimited read/write":
-      proc writeWorker(server: ptr Listener[TCP]) {.thread.} =
-        ## Accepts a connection then write test data to it, closing it afterwards
-        {.gcsafe.}:
-          let (conn, _) = server[].accept()
-          # Send the sample data
-          conn.accumlatedWrite TestDelimitedData
+  test "AsyncConn[TCP] delimited read / write":
+    proc writeWorker(server: AsyncListener[TCP]) {.asyncio.} =
+      ## Accepts a connection then write test data to it, closing it afterwards
+      let (conn, _) = server.accept()
+      # Send the sample data
+      conn.accumlatedWrite TestDelimitedData
 
-      var server = listenTcp(IP4Loopback, PortNone)
-      var thr: Thread[ptr Listener[TCP]]
-      thr.createThread(writeWorker, addr server)
+      # Close to signal completion
+      close conn
+
+    proc runner() {.asyncio.} =
+      # Creates the server
+      var server = listenTcpAsync(IP4Loopback, PortNone)
+      # Run the worker until it is dismissed
+      discard trampoline:
+        whelp writeWorker(server)
 
       # Connect to the server
-      let conn = connectTcp(server.localEndpoint)
+      let conn = connectTcpAsync(server.localEndpoint)
 
-      # Read from the server and verify the data
+      # Retrieve the data
       check conn.delimitedRead(Delimiter) == TestDelimitedData
 
-      # Collect the writer
-      joinThread thr
-
-    test "AsyncConn[TCP] EOF read":
-      proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
-        ## A server that accept a connection then drops it
-        ## immediately
-        close server.accept().conn
-
-      proc runner() {.asyncio.} =
-        let server = listenTcpAsync(IP4Loopback, PortNone)
-        # Run the worker until it is dismissed
-        discard trampoline:
-          whelp acceptWorker(server)
-
-        # Connect to the server
-        let client = connectTcpAsync(server.localEndpoint)
-
-        # Our connection should be dropped and reading should yields nothing.
-        var str = new string
-        str[] = newString(10)
-        check client.read(str) == 0
-
-      # Start the test
-      runner()
-      # Run the IO queue to completion
-      run()
-
-    test "AsyncConn[TCP] EOF write with big buffers":
-      proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
-        ## A server that accept a connection then drops it
-        ## immediately
-        close server.accept().conn
-
-      proc runner() {.asyncio.} =
-        var server = listenTcpAsync(IP4Loopback, PortNone)
-        # Run the worker until it is dismissed
-        discard trampoline:
-          whelp acceptWorker(server)
-
-        # Connect to the server
-        let client = connectTcpAsync(server.localEndpoint)
-
-        # Our connection should be dropped and writing should error.
-        #
-        # It is expected that there might be some data written due
-        # to operating system maintaining a local buffer.
-        expect files.IOError:
-          # Some repeats will be necessary as some operating systems buffers
-          # data and won't trigger a send immediately, thus not raising the
-          # error.
-          var i = 0
-          while i < 10:
-            discard client.write(TestBufferedData)
-            inc i
-
-      # Start the test
-      runner()
-      # Run the IO queue to completion
-      run()
-
-    test "AsyncConn[TCP] zero read":
-      proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
-        ## A server that accept a connection then drops it
-        ## immediately
-        close server.accept().conn
-
-      proc runner() {.asyncio.} =
-        let server = listenTcpAsync(IP4Loopback, PortNone)
-        # Run the worker until it is dismissed
-        discard trampoline:
-          whelp acceptWorker(server)
-
-        # Connect to the server
-        let client = connectTcpAsync(server.localEndpoint)
-
-        var str = new string
-        check client.read(str) == 0
-
-        var sq = new string
-        check client.read(sq) == 0
-
-        check client.read(nil, 0) == 0
-
-      # Start the test
-      runner()
-      # Run the IO queue to completion
-      run()
-
-    test "AsyncConn[TCP] zero write":
-      proc acceptWorker(server: AsyncListener[TCP]): AsyncConn[TCP] {.asyncio.} =
-        ## A server that accept a connection
-        # Return it so it won't get closed immediately
-        result = server.accept().conn
-
-      proc runner() {.asyncio.} =
-        let server = listenTcpAsync(IP4Loopback, PortNone)
-        # Keep a reference to the worker so we can keep the connection alive
-        let worker = whelp acceptWorker(server)
-        # Tramp it
-        discard trampoline worker
-
-        # Connect to the server
-        let client = connectTcpAsync(server.localEndpoint)
-
-        check client.write("") == 0
-        check client.write(default seq[byte]) == 0
-
-        var str = new string
-        check client.write(str) == 0
-
-        var sq = new seq[byte]
-        check client.write(sq) == 0
-
-        check client.write(nil, 0) == 0
-
-      # Start the test
-      runner()
-      # Run the IO queue to completion
-      run()
-
-    test "AsyncConn[TCP] read/write":
-      proc writeWorker(server: AsyncListener[TCP]) {.asyncio.} =
-        ## Accepts a connection then write test data to it, closing it afterwards
-        let (conn, _) = server.accept()
-        # Send the sample data
-        conn.accumlatedWrite TestBufferedData
-
-        # Close to signal completion
-        close conn
-
-      proc runner() {.asyncio.} =
-        # Creates the server
-        var server = listenTcpAsync(IP4Loopback, PortNone)
-        # Run the worker until it is dismissed
-        discard trampoline:
-          whelp writeWorker(server)
-
-        # Connect to the server
-        let conn = connectTcpAsync(server.localEndpoint)
-
-        # Retrieve the data
-        check conn.accumlatedRead(TestBufferedData.len + 1024) == TestBufferedData
-
-      # Run the test
-      runner()
-      # Run the IO queue to completion
-      run()
-
-    test "AsyncConn[TCP] delimited read / write":
-      proc writeWorker(server: AsyncListener[TCP]) {.asyncio.} =
-        ## Accepts a connection then write test data to it, closing it afterwards
-        let (conn, _) = server.accept()
-        # Send the sample data
-        conn.accumlatedWrite TestDelimitedData
-
-        # Close to signal completion
-        close conn
-
-      proc runner() {.asyncio.} =
-        # Creates the server
-        var server = listenTcpAsync(IP4Loopback, PortNone)
-        # Run the worker until it is dismissed
-        discard trampoline:
-          whelp writeWorker(server)
-
-        # Connect to the server
-        let conn = connectTcpAsync(server.localEndpoint)
-
-        # Retrieve the data
-        check conn.delimitedRead(Delimiter) == TestDelimitedData
-
-      # Run the test
-      runner()
-      # Run the IO queue to completion
-      run()
+    # Run the test
+    runner()
+    # Run the IO queue to completion
+    run()

--- a/tests/sockets/tsockets.nim
+++ b/tests/sockets/tsockets.nim
@@ -78,7 +78,7 @@ when defined(posix):
       var str = newString(10)
       check client.read(str) == 0
 
-    test "Conn[TCP] EOF write":
+    test "Conn[TCP] EOF write with big buffers":
       proc acceptWorker(srv: ptr Listener[TCP]) {.thread.} =
         ## A server that accept a connection then drops it
         ## immediately
@@ -103,7 +103,7 @@ when defined(posix):
         # Some repeats will be necessary as some operating systems buffers data
         # and won't trigger a send immediately, thus not raising the error.
         for _ in 1 .. 10:
-          discard client.write("test data")
+          discard client.write(TestBufferedData)
 
     test "Conn[TCP] zero read":
       var l: Lock
@@ -234,13 +234,7 @@ when defined(posix):
       # Run the IO queue to completion
       run()
 
-    test "AsyncConn[TCP] EOF write":
-      # After many tries Linux just keep reporting EWOULDBLOCK.
-      #
-      # This is likely to be the same on other OS, this behavior can't be
-      # relied upon.
-      skip "Unable to confirm the behavior under Linux"
-
+    test "AsyncConn[TCP] EOF write with big buffers":
       proc acceptWorker(server: AsyncListener[TCP]) {.asyncio.} =
         ## A server that accept a connection then drops it
         ## immediately
@@ -265,7 +259,7 @@ when defined(posix):
           # error.
           var i = 0
           while i < 10:
-            discard client.write("test data")
+            discard client.write(TestBufferedData)
             inc i
 
       # Start the test

--- a/tests/sockets/tsockets.nims
+++ b/tests/sockets/tsockets.nims
@@ -1,0 +1,1 @@
+--threads:on


### PR DESCRIPTION
Design:
- `Socket` base for common operations
- Specialized `Conn[Protocol]` and `Listener[Protocol]`
  - `Conn`:
    - `connect`, `read` and `write` as basic primitives
  - `Listener`:
    - `listen`, `accept` as basic primitives

Current progress:
- [x] Platform support
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [ ] Networking protocols
  - [x] TCP
  - [ ] UDP
  - [ ] Unix
- [ ] Address families
  - [x] IPv4
  - [ ] IPv6
  - [ ] Unix
- [ ] Features
  - [ ] Asynchronous resolver
  - [ ] Pluggable resolver
  - [ ] `Listener`
    - [ ] Generic `listen()` interface
      - [ ] Use any iterable list of endpoints for local binding
    - [ ] Dual-stack IPv4/IPv6
  - [ ] `Conn`
    - [ ] Generic `connect()` interface
      - [ ] Use any iterable list of endpoints for initiating connection
    - [ ] Timeout for I/O

Closes #22