### PR TITLE
sys(treewide): update cps to 0.6.0

### DIFF
--- a/sys.nimble
+++ b/sys.nimble
@@ -11,7 +11,7 @@ srcDir        = "src"
 
 requires "nim >= 1.5.1"
 requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
-requires "https://github.com/disruptek/cps >= 0.4.2 & < 0.5.0"
+requires "https://github.com/nim-works/cps >= 0.6.0 & < 0.7.0"
 
 # Bundled as submodule instead since the package can only be installed on Windows.
 # requires "https://github.com/khchen/winim#bffaf742b4603d1f675b4558d250d5bfeb8b6630"


### PR DESCRIPTION
CPS has already changed home to nim-works. The new release also brought
in the removal of `()` operator which has been causing trouble in the
past with generics in nim-sys.