### PR TITLE
handles: change storage strategy and conform API

### DIFF
--- a/src/sys/ioqueue.nim
+++ b/src/sys/ioqueue.nim
@@ -191,6 +191,6 @@ proc unregister*(fd: AnyFD) =
   ##   *after* it and its duplicates are closed.
   unregisterImpl()
 
-proc unregister*(fd: Handle[AnyFD]) =
+proc unregister*(handle: Handle[AnyFD]) =
   ## An overload of `unregister` for `Handle`
-  ioqueue.unregister(fd.get)
+  ioqueue.unregister(handle.fd)

--- a/src/sys/ioqueue/iocp.nim
+++ b/src/sys/ioqueue/iocp.nim
@@ -102,7 +102,7 @@ proc poll(runnable: var seq[Continuation], timeout = none(Duration)) {.used.} =
   # Obtain completion events
   var selected: ULONG
   if GetQueuedCompletionStatusEx(
-    wincore.Handle(eq.iocp.get), addr eq.eventBuffer[0], ULONG(eq.eventBuffer.len),
+    wincore.Handle(eq.iocp.fd), addr eq.eventBuffer[0], ULONG(eq.eventBuffer.len),
     addr selected, timeout, wincore.FALSE
   ) == wincore.FALSE:
     let errorCode = GetLastError()
@@ -150,7 +150,7 @@ proc persist(fd: AnyFD) {.raises: [OSError].} =
 
   # Register the handle with IOCP
   if CreateIoCompletionPort(
-    wincore.Handle(fd), wincore.Handle(eq.iocp.get), ULongPtr(fd), 0
+    wincore.Handle(fd), wincore.Handle(eq.iocp.fd), ULongPtr(fd), 0
   ) == wincore.Handle(0):
     let errorCode = GetLastError()
 

--- a/src/sys/private/files_posix.nim
+++ b/src/sys/private/files_posix.nim
@@ -31,11 +31,11 @@ template newAsyncFileImpl() {.dirty.} =
   result = AsyncFile newFile(fd)
 
 template getFDImpl() {.dirty.} =
-  result = get f.handle
+  result = f.handle.fd
 
 template takeFDImpl() {.dirty.} =
   cleanupFile f
-  result = take f.handle
+  result = f.handle.takeFd
 
 proc commonRead(fd: FD, buf: pointer, len: Natural): int {.inline.} =
   ## A wrapper around posix.read() to retry on EINTR.

--- a/src/sys/private/files_windows.nim
+++ b/src/sys/private/files_windows.nim
@@ -46,11 +46,11 @@ template newAsyncFileImpl() {.dirty.} =
   result[] = AsyncFileImpl fileImpl
 
 template getFDImpl() {.dirty.} =
-  result = get f.handle
+  result = f.handle.fd
 
 template takeFDImpl() {.dirty.} =
   cleanupFile f
-  result = take f.handle
+  result = f.handle.takeFd
 
 proc initOverlapped(f: FileImpl, o: var Overlapped) {.inline.} =
   ## Initialize an overlapped object for I/O operations on `f`

--- a/src/sys/private/handles_posix.nim
+++ b/src/sys/private/handles_posix.nim
@@ -43,6 +43,17 @@ template setBlockingImpl() {.dirty.} =
     flags = flags or O_NONBLOCK
   posixChk fcntl(fd.cint, F_SETFL, flags), ErrorSetBlocking
 
+template getFdImpl() {.dirty.} =
+  cast[T](cast[cuint](h.shiftedFd) - 1)
+
+template setFdImpl() {.dirty.} =
+  # The FD is casted to unsigned so that `high(cint)` can be mapped forward
+  # correctly.
+  #
+  # As all architectures running Linux uses two's complement, this also handles
+  # InvalidFD -> 0 correctly.
+  h.shiftedFd = cast[FDImpl](cast[cuint](fd) + 1)
+
 when false:
   # NOTE: Staged until process spawning is added.
   template duplicateImpl() {.dirty.} =

--- a/src/sys/private/handles_windows.nim
+++ b/src/sys/private/handles_windows.nim
@@ -34,3 +34,9 @@ template setInheritableImpl() {.dirty.} =
       raise newOSError(GetLastError(), ErrorSetInheritable)
   else:
     {.error: "setInheritable is not available for this variant of FD".}
+
+template getFdImpl() {.dirty.} =
+  cast[T](cast[uint](h.shiftedFd - 1))
+
+template setFdImpl() {.dirty.} =
+  h.shiftedFd = cast[FDImpl](cast[uint](fd) + 1)


### PR DESCRIPTION
Since https://github.com/nim-lang/Nim/issues/19139 was closed as a
"won't fix", the "workaround" has to become permanent.

If we are to store a boolean next to the FD, it would double the
structure size, which is undesirable.

Instead, storage is now done via a lossless map so that zero-ed values
are invalid by default.

In this commit, Handle[T] API is changed to match other parts of the
project. In short:

* `get` -> `fd`
* `take` -> `takeFd`