### PR TITLE
sys(treewide): purge implicitDeref from the codebase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         arch: [i386, amd64]
         include:
           - target: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
           - target: macos
-            builder: macos-10.15
+            builder: macos-11
           - target: windows
             builder: windows-2019
           - target: linux
@@ -23,7 +23,7 @@ jobs:
         exclude:
           - target: macos
             arch: i386
-    name: '${{ matrix.target }} on ${{ matrix.arch }} (Nim ${{ matrix.branch }})'
+    name: "${{ matrix.target }} on ${{ matrix.arch }} (Nim ${{ matrix.branch }})"
     runs-on: ${{ matrix.builder }}
 
     defaults:
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3.0.2
         with:
           path: nim-sys
-          submodules: 'recursive'
+          submodules: "recursive"
 
       - name: Configure Nim for 32 bit GCC (Linux-only)
         if: matrix.arch == 'i386' && runner.os == 'Linux'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ htmldocs
 *
 !/**/
 !*.*
+nimble.develop
+nimble.paths

--- a/src/sys/files.nim
+++ b/src/sys/files.nim
@@ -6,8 +6,6 @@
 # the file "license.txt" included with this distribution. Alternatively,
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
-{.experimental: "implicitDeref".}
-
 import system except io
 import handles, ioqueue
 import private/errors
@@ -64,7 +62,7 @@ proc newIOError*(bytesTransferred: Natural, errorCode: int32,
                  additionalInfo = ""): ref IOError =
   ## Creates a new `ref IOError`.
   result = new IOError
-  result.initIOError(bytesTransferred, errorCode, additionalInfo)
+  result[].initIOError(bytesTransferred, errorCode, additionalInfo)
 
 proc `=copy`*(dest: var FileImpl, src: FileImpl) {.error.}
   ## Copying a `File` is not allowed. If multiple references to the same file
@@ -205,8 +203,8 @@ proc read*(f: AsyncFile, b: ref string): int {.asyncio.} =
   ## `read() <#read,AsyncFile,ptr.UncheckedArray[byte],Natural>`_, please refer
   ## to its documentation for more information.
   assert(not b.isNil, "The provided buffer must not be nil")
-  if b.len > 0:
-    read(f, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+  if b[].len > 0:
+    read(f, cast[ptr UncheckedArray[byte]](addr b[][0]), b[].len)
   else:
     read(f, nil, 0)
 
@@ -217,8 +215,8 @@ proc read*(f: AsyncFile, b: ref seq[byte]): int {.asyncio.} =
   ## `read() <#read,AsyncFile,ptr.UncheckedArray[byte],Natural>`_, please refer
   ## to its documentation for more information.
   assert(not b.isNil, "The provided buffer must not be nil")
-  if b.len > 0:
-    read(f, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+  if b[].len > 0:
+    read(f, cast[ptr UncheckedArray[byte]](addr b[][0]), b[].len)
   else:
     read(f, nil, 0)
 
@@ -291,8 +289,8 @@ proc write*(f: AsyncFile, b: ref string): int {.asyncio.} =
   ## `write() <#write,AsyncFile,ptr.UncheckedArray[byte],Natural>`_, please
   ## refer to its documentation for more information.
   assert(not b.isNil, "The provided buffer must not be nil")
-  if b.len > 0:
-    write(f, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+  if b[].len > 0:
+    write(f, cast[ptr UncheckedArray[byte]](addr b[][0]), b[].len)
   else:
     write(f, nil, 0)
 
@@ -315,7 +313,7 @@ proc write*(f: AsyncFile, b: ref seq[byte]): int {.asyncio.} =
   ## `write() <#write,AsyncFile,ptr.UncheckedArray[byte],Natural>`_, please
   ## refer to its documentation for more information.
   assert(not b.isNil, "The provided buffer must not be nil")
-  if b.len > 0:
-    write(f, cast[ptr UncheckedArray[byte]](addr b[0]), b.len)
+  if b[].len > 0:
+    write(f, cast[ptr UncheckedArray[byte]](addr b[][0]), b[].len)
   else:
     write(f, nil, 0)

--- a/src/sys/private/errors.nim
+++ b/src/sys/private/errors.nim
@@ -7,8 +7,6 @@
 # the file "license.txt" included with this distribution. Alternatively,
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
-{.experimental: "implicitDeref".}
-
 from std/os import osErrorMsg, OSErrorCode
 from syscall/posix import errno
 
@@ -27,7 +25,7 @@ template initOSError*(e: var OSError, errorCode: int32,
 
 proc newOSError*(errorCode: int32, additionalInfo = ""): ref OSError {.inline.} =
   result = new OSError
-  result.initOSError(errorCode, additionalInfo)
+  result[].initOSError(errorCode, additionalInfo)
 
 template posixChk*(op: untyped, errmsg: string = ""): untyped =
   ## Check whether the operation finished without error.

--- a/src/sys/private/files_windows.nim
+++ b/src/sys/private/files_windows.nim
@@ -107,7 +107,7 @@ template asyncReadImpl() {.dirty.} =
   let overlapped = new Overlapped
 
   # Prepare the OVERLAPPED structure
-  f.File.initOverlapped(overlapped[])
+  f.File[].initOverlapped(overlapped[])
 
   var
     errorCode: DWORD = ErrorSuccess
@@ -170,7 +170,7 @@ template asyncWriteImpl() {.dirty.} =
   let overlapped = new Overlapped
 
   # Prepare the OVERLAPPED structure
-  f.File.initOverlapped(overlapped[])
+  f.File[].initOverlapped(overlapped[])
 
   var
     errorCode: DWORD = ErrorSuccess

--- a/sys.nimble
+++ b/sys.nimble
@@ -10,8 +10,8 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.5.1"
-requires "https://github.com/disruptek/balls >= 3.0.0 & < 4.0.0"
-requires "https://github.com/nim-works/cps >= 0.6.0 & < 0.7.0"
+requires "https://github.com/disruptek/balls >= 3.9.0 & < 4.0.0"
+requires "https://github.com/nim-works/cps >= 0.8.0 & < 0.9.0"
 
 # Bundled as submodule instead since the package can only be installed on Windows.
 # requires "https://github.com/khchen/winim#bffaf742b4603d1f675b4558d250d5bfeb8b6630"

--- a/tests/ioqueue/tqueue.nim
+++ b/tests/ioqueue/tqueue.nim
@@ -1,5 +1,3 @@
-{.experimental: "implicitDeref".}
-
 import std/[os, strutils]
 import pkg/balls
 import sys/[ioqueue, handles]
@@ -18,11 +16,11 @@ suite "Test queue":
   test "Multiple waiters for read/write":
     var (rd, wr) = newAsyncPipe()
     defer:
-      unregister rd
-      unregister wr
+      unregister rd[]
+      unregister wr[]
 
     var str = new string
-    str.setLen(BigTestData.len)
+    str[].setLen(BigTestData.len)
 
     # Start the reader, it will suspend because there's nothing to read
     rd.readAsync(str)
@@ -34,4 +32,4 @@ suite "Test queue":
     # Let's run this mess
     run()
 
-    check str == BigTestData
+    check str[] == BigTestData

--- a/tests/ioqueue/tready.nim
+++ b/tests/ioqueue/tready.nim
@@ -1,5 +1,3 @@
-{.experimental: "implicitDeref".}
-
 when defined(linux) or defined(macosx) or defined(bsd):
   import std/[posix, os, strutils]
   import pkg/[cps, balls]
@@ -20,34 +18,34 @@ when defined(linux) or defined(macosx) or defined(bsd):
     test "Ready to read":
       var (rd, wr) = newAsyncPipe()
       defer:
-        unregister rd
-        unregister wr
+        unregister rd[]
+        unregister wr[]
 
       let str = new string
-      str.setLen(TestData.len)
+      str[].setLen(TestData.len)
       # Start the reader first, it will suspend because there's nothing
       # to read from
       readAsync(rd, str)
 
       # Write our payload, it's small so it won't block
-      wr.write(TestData)
+      wr[].write(TestData)
       # Close to signify completion
-      close wr
+      close wr[]
 
       # Run the dispatcher, which should finish our read
       run()
 
-      check str == TestData
+      check str[] == TestData
 
     test "Ready to write":
       var (rd, wr) = newAsyncPipe()
       defer:
-        unregister rd
-        unregister wr
+        unregister rd[]
+        unregister wr[]
 
       # Fill our buffer til we can't write anymore
       try:
-        wr.write(BigTestData)
+        wr[].write(BigTestData)
         fail "we couldn't fill the buffer"
       except files.IOError as e:
         if e.errorCode != EAGAIN:
@@ -62,7 +60,7 @@ when defined(linux) or defined(macosx) or defined(bsd):
       var str = newString(BigTestData.len)
       # We should be able to empty the buffer in one swoop
       try:
-        discard rd.read(str)
+        discard rd[].read(str)
         fail "we couldn't empty the buffer"
       except files.IOError as e:
         if e.errorCode != EAGAIN:
@@ -71,10 +69,10 @@ when defined(linux) or defined(macosx) or defined(bsd):
       # Run the dispatcher, our writer should start writing now
       run()
       # Close our write line so that read knows that there is nothing left
-      close wr
+      close wr[]
 
       # Read and make sure that we get just enough data
-      check rd.read(str) == TestData.len, "there are more data in the buffer than specified"
+      check rd[].read(str) == TestData.len, "there are more data in the buffer than specified"
 
       str.setLen(TestData.len)
       check str == TestData
@@ -82,11 +80,11 @@ when defined(linux) or defined(macosx) or defined(bsd):
     test "Multiple waiters for read/write":
       var (rd, wr) = newAsyncPipe()
       defer:
-        unregister rd
-        unregister wr
+        unregister rd[]
+        unregister wr[]
 
       var str = new string
-      str.setLen(BigTestData.len)
+      str[].setLen(BigTestData.len)
 
       # Start the reader, it will suspend because there's nothing to read
       rd.readAsync(str)
@@ -98,4 +96,4 @@ when defined(linux) or defined(macosx) or defined(bsd):
       # Let's run this mess
       run()
 
-      check str == BigTestData
+      check str[] == BigTestData

--- a/tests/ioqueue/tunregister.nim
+++ b/tests/ioqueue/tunregister.nim
@@ -1,5 +1,3 @@
-{.experimental: "implicitDeref".}
-
 import pkg/[cps, balls]
 import sys/[handles, ioqueue]
 
@@ -9,11 +7,11 @@ suite "Unregistering FD from queue":
   test "Unregistering FD prevents its continuation from being run":
     let (rd, wr) = newAsyncPipe()
     defer:
-      close rd
+      close rd[]
 
     proc tester() {.asyncio.} =
       let buf = new string
-      buf.setLen 1
+      buf[].setLen 1
       readAsync(rd, buf)
       fail "This code should not be run"
 
@@ -21,10 +19,10 @@ suite "Unregistering FD from queue":
     tester()
 
     # Close the write side, which will unblock the pipe
-    close wr
+    close wr[]
 
     # Unregister the pipe
-    unregister rd
+    unregister rd[]
 
     # Run the queue, the proc should not continue
     run()

--- a/tests/pipes/tpipe.nim
+++ b/tests/pipes/tpipe.nim
@@ -4,8 +4,6 @@ import pkg/balls
 import sys/[pipes, files, private/syscall/posix, ioqueue]
 import ".."/helpers/io
 
-{.experimental: "implicitDeref".}
-
 const Delimiter = "\c\l\c\l"
   # The HTTP delimiter
 
@@ -121,9 +119,9 @@ suite "Test Pipe read/write behaviors":
   test "Pipe long read/write":
     proc writeWorker(wr: ptr WritePipe) {.thread.} =
       {.gcsafe.}:
-        wr.accumlatedWrite TestBufferedData
+        wr[].accumlatedWrite TestBufferedData
         # Signal that we are done
-        close wr
+        close wr[]
 
     var (rd, wr) = newPipe()
     var thr: Thread[ptr WritePipe]
@@ -160,7 +158,7 @@ suite "Test Pipe read/write behaviors":
   test "Sync read and async write test":
     proc readWorker(rd: ptr ReadPipe) {.thread.} =
       {.gcsafe.}:
-        check rd.accumlatedRead(TestBufferedData.len + 1024) == TestBufferedData
+        check rd[].accumlatedRead(TestBufferedData.len + 1024) == TestBufferedData
 
     var (rd, wr) = newPipe(Wr = AsyncWritePipe)
     var thr: Thread[ptr ReadPipe]
@@ -185,9 +183,9 @@ suite "Test Pipe read/write behaviors":
   test "Async read and sync write test":
     proc writeWorker(wr: ptr WritePipe) {.thread.} =
       {.gcsafe.}:
-        wr.accumlatedWrite TestBufferedData
+        wr[].accumlatedWrite TestBufferedData
         # Signal that we are done
-        close wr
+        close wr[]
 
     var (rd, wr) = newPipe(Rd = AsyncReadPipe)
     var thr: Thread[ptr WritePipe]
@@ -209,7 +207,7 @@ suite "Test Pipe read/write behaviors":
   test "Pipe delimited read / write":
     proc writeWorker(wr: ptr WritePipe) {.thread.} =
       {.gcsafe.}:
-        wr.accumlatedWrite TestDelimitedData
+        wr[].accumlatedWrite TestDelimitedData
 
     var (rd, wr) = newPipe()
     var thr: Thread[ptr WritePipe]
@@ -244,7 +242,7 @@ suite "Test Pipe read/write behaviors":
   test "Pipe delimited read / AsyncPipe write":
     proc readWorker(rd: ptr ReadPipe) {.thread.} =
       {.gcsafe.}:
-        check rd.delimitedRead(Delimiter) == TestDelimitedData
+        check rd[].delimitedRead(Delimiter) == TestDelimitedData
 
     var (rd, wr) = newPipe(Wr = AsyncWritePipe)
     var thr: Thread[ptr ReadPipe]
@@ -267,7 +265,7 @@ suite "Test Pipe read/write behaviors":
   test "AsyncPipe delimited read / Pipe write":
     proc writeWorker(wr: ptr WritePipe) {.thread.} =
       {.gcsafe.}:
-        wr.accumlatedWrite TestDelimitedData
+        wr[].accumlatedWrite TestDelimitedData
 
     var (rd, wr) = newPipe(Rd = AsyncReadPipe)
     var thr: Thread[ptr WritePipe]


### PR DESCRIPTION
Unfortunately this feature has been removed from upstream Nim.

This makes the API terrible to use, but we have to deal with it for now.