### PR TITLE
syscall/kqueue: use FreeBSD 12 and newer structures

### DIFF
--- a/src/sys/private/syscall/bsd/kqueue_fbsd.ld
+++ b/src/sys/private/syscall/bsd/kqueue_fbsd.ld
@@ -1,7 +1,0 @@
-VERSION {
-  FBSD_1.0 {
-    extern "C" {
-      kevent;
-    };
-  };
-};


### PR DESCRIPTION
Testing shown that the linker script does not work and I could not make it work, so the alternative is to use FreeBSD 12+ structure.