### PR TITLE
ioqueue(linux): make queue a concrete procedure

### DIFF
--- a/src/sys/private/ioqueue_linux.nim
+++ b/src/sys/private/ioqueue_linux.nim
@@ -76,7 +76,7 @@ func toEvents(ev: Ev): set[Event] =
   if ev.has EvPri:
     result.incl PriorityRead
 
-proc queue(eq: var EventQueueImpl, cont: Continuation, fd: AnyFD, event: ReadyEvent) =
+proc queue(eq: var EventQueueImpl, cont: Continuation, fd: FD, event: ReadyEvent) =
   var epEvent = epoll.Event(events: toEv({event}), data: Data(fd: fd.cint))
   # If adding `fd` to epoll fails
   if eq.epoll.fd.ctl(CtlAdd, fd, epEvent) == -1:


### PR DESCRIPTION
queue() being a generic caused trouble in generic sandwich prone cases. queue() has not needed to be a generic taking AnyFD for quite awhile now, so this fix is simply a prototype change.