### PR TITLE
sockets: drop AI_ADDRCONFIG from getaddrinfo calls

### DIFF
--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -106,7 +106,7 @@ template ip4Resolve() {.dirty.} =
 
   let hints = AddrInfo(
     ai_family: AF_INET,
-    ai_flags: AI_NUMERICSERV or AI_ADDRCONFIG
+    ai_flags: AI_NUMERICSERV
   )
 
   let err = getaddrinfo(

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -161,7 +161,6 @@ template ip4Resolve() {.dirty.} =
   result = new ResolverResultImpl
 
   let hints = AddrInfoW(
-    ai_flags: AI_ADDRCONFIG,
     ai_family: AF_INET
   )
 


### PR DESCRIPTION
This flag implementation is known to be troublesome: https://fedoraproject.org/wiki/QA/Networking/NameResolution/ADDRCONFIG

Also, it would prevent users from explicitly requesting for IPv6 addresses on systems where *outbound* IPv6 is not available, which might be a surprising behavior.

According to Fedora's documentation, glibc will sort the addresses so that the best address is the first one, so this flag does not give us a lot in terms of optimization there.