### PR TITLE
ci: replace concurrent_skipping with PR-only runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -23,7 +27,6 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5.3.1
         with:
           paths_ignore: '["**/readme.md"]'
-          concurrent_skipping: same_content_newer
 
   build:
     needs: context


### PR DESCRIPTION
Only run workflow on PR and pushes to master.

This replaces concurrent_skipping as the feature did not distinguish correctly between PRs and pushes, allowing PRs to skip required checks.