### PR TITLE
ci: don't double wrap page artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,9 +227,12 @@ jobs:
       - name: Upload pages artifact
         if:
           needs.context.outputs.skip-reason == 'skip_after_successful_duplicate'
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-artifact@v4.3.1
         with:
-          path: page
+          name: github-pages
+          path: page/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Deploy page
         id: deployment


### PR DESCRIPTION
The artifact is packaged nicely into a .tar file. All we have to do is to reupload it instead of running the whole upload-pages again.