### PR TITLE
sockets: fix string lifetime for getaddrinfo

### DIFF
--- a/src/sys/private/sockets_posix.nim
+++ b/src/sys/private/sockets_posix.nim
@@ -104,20 +104,22 @@ proc `=destroy`(r: var ResolverResultImpl) =
 template ipResolve() {.dirty.} =
   result = new ResolverResultImpl
 
-  let hints = AddrInfo(
-    ai_family:
-      if isNone(kind):
-        AF_UNSPEC
-      else:
-        case kind.get
-        of V4: AF_INET
-        of V6: AF_INET6,
-    ai_flags: AI_NUMERICSERV
-  )
+  let
+    hints = AddrInfo(
+      ai_family:
+        if isNone(kind):
+          AF_UNSPEC
+        else:
+          case kind.get
+          of V4: AF_INET
+          of V6: AF_INET6,
+      ai_flags: AI_NUMERICSERV
+    )
+    portStr = if port == PortNone: "" else: $port
 
   let err = getaddrinfo(
     cstring(host),
-    if port == PortNone: nil else: cstring($port),
+    cstring(portStr),
     unsafeAddr hints,
     result.info
   )

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -160,20 +160,23 @@ proc `=destroy`(r: var ResolverResultImpl) =
 template ipResolve() {.dirty.} =
   result = new ResolverResultImpl
 
-  let hints = AddrInfoW(
-    ai_family:
-      if isNone(kind):
-        AF_UNSPEC
-      else:
-        case kind.get
-        of V4: AF_INET
-        of V6: AF_INET6
-  )
+  let
+    hints = AddrInfoW(
+      ai_family:
+        if isNone(kind):
+          AF_UNSPEC
+        else:
+          case kind.get
+          of V4: AF_INET
+          of V6: AF_INET6
+    )
+    hostLStr = L(host)
+    portLStr = if port == PortNone: L"" else: L($port)
 
   let err = GetAddrInfoW(
     # Convert host to wide string then pass the pointer
-    &L(host),
-    &L($port),
+    &hostLStr,
+    &portLStr,
     unsafeAddr hints,
     addr result.info
   )

--- a/tests/sockets/tip.nim
+++ b/tests/sockets/tip.nim
@@ -14,8 +14,10 @@ suite "IP address testing":
     for ep in resolveIP("localhost").items:
       if ep.kind == V4 and ep.v4.ip == ip4(127, 0, 0, 1):
         foundV4 = true
+        check ep.v4.port == PortNone
       elif ep.kind == V6 and ep.v6.ip == ip6(0, 0, 0, 0, 0, 0, 0, 1):
         foundV6 = true
+        check ep.v6.port == PortNone
 
     check foundV4, "did not find 127.0.0.1 when resolving for localhost"
     check foundV6, "did not find ::1 when resolving for localhost"
@@ -25,6 +27,7 @@ suite "IP address testing":
     for ep in resolveIP("localhost", kind = some(V4)).items:
       if ep.kind == V4 and ep.v4.ip == ip4(127, 0, 0, 1):
         foundV4 = true
+        check ep.v4.port == PortNone
       elif ep.kind == V6:
         check false, "found IPv6 for localhost but configured to resolve only IPv4 addresses"
 
@@ -34,6 +37,29 @@ suite "IP address testing":
     for ep in resolveIP("localhost", kind = some(V6)).items:
       if ep.kind == V6 and ep.v6.ip == ip6(0, 0, 0, 0, 0, 0, 0, 1):
         foundV6 = true
+        check ep.v6.port == PortNone
+      elif ep.kind == V4:
+        check false, "found IPv4 for localhost but configured to resolve only IPv6 addresses"
+
+    check foundV6, "did not find ::1 when resolving for localhost"
+
+  test "Resolve for localhost with port":
+    const port = 8080.Port
+    var foundV4 = false
+    for ep in resolveIP("localhost", port, kind = some(V4)).items:
+      if ep.kind == V4 and ep.v4.ip == ip4(127, 0, 0, 1):
+        foundV4 = true
+        check ep.v4.port == port
+      elif ep.kind == V6:
+        check false, "found IPv6 for localhost but configured to resolve only IPv4 addresses"
+
+    check foundV4, "did not find 127.0.0.1 when resolving for localhost"
+
+    var foundV6 = false
+    for ep in resolveIP("localhost", port, kind = some(V6)).items:
+      if ep.kind == V6 and ep.v6.ip == ip6(0, 0, 0, 0, 0, 0, 0, 1):
+        foundV6 = true
+        check ep.v6.port == port
       elif ep.kind == V4:
         check false, "found IPv4 for localhost but configured to resolve only IPv6 addresses"
 


### PR DESCRIPTION
The expression we used for `getaddrinfo()` invocation might cause the underlying strings to be deallocated before they are sent to `getaddrinfo()`, which would result in use-after-free issues.

Also added more tests for resolveIP + having a port set.