### PR TITLE
files, sockets: ignore cleanup exceptions on =destroy

### DIFF
--- a/src/sys/private/files_posix.nim
+++ b/src/sys/private/files_posix.nim
@@ -21,7 +21,11 @@ template closeImpl() {.dirty.} =
   close f.handle
 
 template destroyFileImpl() {.dirty.} =
-  cleanupFile f
+  try:
+    cleanupFile f
+  except CatchableError:
+    discard "Nothing can be done here"
+
   `=destroy` f.handle
 
 template newFileImpl() {.dirty.} =

--- a/src/sys/private/files_windows.nim
+++ b/src/sys/private/files_windows.nim
@@ -29,7 +29,11 @@ template closeImpl() {.dirty.} =
   close f.handle
 
 template destroyFileImpl() {.dirty.} =
-  cleanupFile f
+  try:
+    cleanupFile f
+  except CatchableError:
+    discard "Nothing can be done here"
+
   `=destroy` f.handle
 
 template newFileImpl() {.dirty.} =


### PR DESCRIPTION
In these situations there are only two reasons why cleaning up fails:

* The FD is invalid
* There is something wrong with the OS

The first case is already covered by Defects, which are not ignored, and we can't do anything (nor can the caller) for the second case, so just ignore those.

This is brought on by nimskull 0.1.0-dev.21268, which disallows raise in hooks since that was undefined behavior.