### PR TITLE
sys(treewide): unbundle winim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           path: nim-sys
-          submodules: "recursive"
 
       - name: Configure Nim for 32 bit GCC (Linux-only)
         if: matrix.arch == 'i386' && runner.os == 'Linux'
@@ -215,8 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download github-pages artifact
-        if:
-          needs.context.outputs.skip-reason == 'skip_after_successful_duplicate'
+        if: needs.context.outputs.skip-reason == 'skip_after_successful_duplicate'
         uses: actions/download-artifact@v4.1.4
         with:
           name: github-pages
@@ -225,8 +223,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Upload pages artifact
-        if:
-          needs.context.outputs.skip-reason == 'skip_after_successful_duplicate'
+        if: needs.context.outputs.skip-reason == 'skip_after_successful_duplicate'
         uses: actions/upload-artifact@v4.3.1
         with:
           name: github-pages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/sys/private/syscall/winim"]
-	path = src/sys/private/syscall/winim
-	url = https://github.com/khchen/winim

--- a/src/sys/ioqueue/iocp.nim
+++ b/src/sys/ioqueue/iocp.nim
@@ -11,7 +11,7 @@ import pkg/cps
 import ".."/handles
 
 import ".."/private/[ioqueue_common, errors]
-import ".."/private/syscall/winim/winim/core as wincore except Handle, Error
+import pkg/winim/core as wincore except Handle, Error
 
 ## Windows-specific implementation of `ioqueue`.
 ##

--- a/src/sys/private/addresses_windows.nim
+++ b/src/sys/private/addresses_windows.nim
@@ -6,7 +6,7 @@
 # the file "license.txt" included with this distribution. Alternatively,
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
-import syscall/winim/winim/core as wincore except Handle
+import pkg/winim/core as wincore except Handle
 
 type
   IP4Impl {.borrow: `.`.} = distinct InAddr

--- a/src/sys/private/files_windows.nim
+++ b/src/sys/private/files_windows.nim
@@ -8,7 +8,7 @@
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
 from std/os import OSErrorCode
-import syscall/winim/winim/core as wincore except Handle
+import pkg/winim/core as wincore except Handle
 
 type
   FileImpl = object

--- a/src/sys/private/handles_windows.nim
+++ b/src/sys/private/handles_windows.nim
@@ -6,7 +6,7 @@
 # the file "license.txt" included with this distribution. Alternatively,
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
-import syscall/winim/winim/core as wincore except Handle
+import pkg/winim/core as wincore except Handle
 import errors
 
 type FDImpl = wincore.Handle

--- a/src/sys/private/pipes_windows.nim
+++ b/src/sys/private/pipes_windows.nim
@@ -7,7 +7,7 @@
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
 import std/strformat
-import syscall/winim/winim/core as wincore except Handle
+import pkg/winim/core as wincore except Handle
 import ".." / handles
 import errors
 
@@ -57,7 +57,7 @@ template newPipeImpl() {.dirty.} =
 
       pipeName = generateUniquePipeName()
       rd = CreateNamedPipeA(
-        cstring(pipeName),
+        addr pipeName[0],
         dwOpenMode = PipeAccessInbound or
           FileFlagFirstPipeInstance or
           rdExtraFlags,
@@ -74,7 +74,7 @@ template newPipeImpl() {.dirty.} =
     if rd == InvalidHandleValue:
       raise newOSError(GetLastError(), ErrorPipeCreation)
 
-    let wr = CreateFileA(cstring(pipeName), GenericWrite, dwShareMode = 0, addr sa,
+    let wr = CreateFileA(addr pipeName[0], GenericWrite, dwShareMode = 0, addr sa,
                          OpenExisting, wrExtraFlags,
                          hTemplateFile = cast[wincore.Handle](nil))
 

--- a/src/sys/private/sockets_windows.nim
+++ b/src/sys/private/sockets_windows.nim
@@ -7,8 +7,8 @@
 # the full text can be found at: https://spdx.org/licenses/MIT.html
 
 from std/os import osErrorMsg, OSErrorCode
-import syscall/winim/winim/core as wincore except Handle
-import syscall/winim/winim/winstr
+import pkg/winim/core as wincore except Handle
+import pkg/winim/winstr
 import ".."/ioqueue/iocp
 import errors
 

--- a/sys.nimble
+++ b/sys.nimble
@@ -13,6 +13,4 @@ when not defined(isNimSkull):
   requires "nim >= 2.0.0"
 requires "https://github.com/nim-works/cps >= 0.11.0 & <0.12.0"
 requires "https://github.com/status-im/nim-stew#3c91b8694e15137a81ec7db37c6c58194ec94a6a"
-
-# Bundled as submodule instead since the package can only be installed on Windows.
-# requires "https://github.com/khchen/winim#bffaf742b4603d1f675b4558d250d5bfeb8b6630"
+requires "https://github.com/khchen/winim >= 3.9.4 & < 4.0.0"

--- a/tests/handles/tdestroy.nim
+++ b/tests/handles/tdestroy.nim
@@ -12,8 +12,8 @@ import ".."/helpers/utils
 import ".."/helpers/handles as helper_handles
 
 when defined(windows):
-  from sys/private/syscall/winim/winim/inc/windef import MakeWord, LoByte, HiByte
-  import sys/private/syscall/winim/winim/inc/winsock
+  from pkg/winim/inc/windef import MakeWord, LoByte, HiByte
+  import pkg/winim/inc/winsock
 
 suite "Test close() and Handle[T] destructions":
   when defined(windows):

--- a/tests/handles/tinherit.nim
+++ b/tests/handles/tinherit.nim
@@ -4,10 +4,10 @@ import sys/handles
 import ".."/helpers/handles as helpers_handles
 
 when defined(windows):
-  import sys/private/syscall/winim/winim
+  from pkg/winim/core as wincore import nil
 
   proc CompareObjectHandles(hFirstObjectHandle,
-                            hSecondObjectHandle: winim.Handle): WinBool
+                            hSecondObjectHandle: wincore.Handle): wincore.WinBool
                            {.importc, stdcall, dynlib: "kernelbase.dll".}
 
 proc testInheritance(fd: FD, expected: bool) =
@@ -56,8 +56,8 @@ proc inheritanceTester() =
         check fd.isValid() == expected
       else:
         check (CompareObjectHandles(
-          cast[winim.Handle](fd),
-          cast[winim.Handle](reference)
+          cast[wincore.Handle](fd),
+          cast[wincore.Handle](reference)
         ) != 0) == expected, "FD " & $cast[uint](fd) & " is " & inheritMsg
 
 proc main() =

--- a/tests/helpers/handles.nim
+++ b/tests/helpers/handles.nim
@@ -15,7 +15,7 @@
 when defined(posix):
   import sys/private/syscall/posix
 else:
-  import sys/private/syscall/winim/winim
+  import pkg/winim/lean
 
 from sys/handles as sys_handles import FD
 

--- a/tests/ioqueue/asyncio.nim
+++ b/tests/ioqueue/asyncio.nim
@@ -12,7 +12,7 @@ when defined(posix):
   import sys/private/syscall/posix
   import ".."/helpers/handles as helper_handle
 else:
-  import sys/private/syscall/winim/winim except Handle
+  import pkg/winim/lean as winim except Handle
 
 import pkg/cps
 import sys/[files, handles, ioqueue]


### PR DESCRIPTION
Remove winim submodule as the main package is now installable on non-Windows platforms.