### PR TITLE
dependabot: group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Group all minor and patch updates together, as they're typically safe to go in one unit.